### PR TITLE
Refer to receivers consistently

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -14,7 +14,7 @@ type AppsCmd struct {
 type AppsListCmd struct{}
 
 // Run executes the `apps list` command
-func (a *AppsListCmd) Run() (err error) {
+func (c *AppsListCmd) Run() (err error) {
 	fmt.Println("omgwtfbbq")
 	return err
 }

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -23,9 +23,9 @@ type DeployCmd struct {
 }
 
 // Run deploys an app to Section's edge
-func (a *DeployCmd) Run() (err error) {
-	if a.Debug {
-		fmt.Println("Server URL:", a.ServerURL)
+func (c *DeployCmd) Run() (err error) {
+	if c.Debug {
+		fmt.Println("Server URL:", c.ServerURL)
 	}
 	path := "./"
 	var files []string
@@ -45,7 +45,7 @@ func (a *DeployCmd) Run() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to walk path: %v", err)
 	}
-	if a.Debug {
+	if c.Debug {
 		for _, file := range files {
 			fmt.Println(file)
 		}
@@ -75,7 +75,7 @@ func (a *DeployCmd) Run() (err error) {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 	}
-	req, err := http.NewRequest(http.MethodPost, a.ServerURL, tempFile)
+	req, err := http.NewRequest(http.MethodPost, c.ServerURL, tempFile)
 	if err != nil {
 		return fmt.Errorf("failed to create upload URL: %v", err)
 	}

--- a/commands/login.go
+++ b/commands/login.go
@@ -11,7 +11,7 @@ import (
 type LoginCmd struct{}
 
 // Run executes the `login` command
-func (a *LoginCmd) Run() (err error) {
+func (c *LoginCmd) Run() (err error) {
 	usr, err := user.Current()
 	if err != nil {
 		panic(err)

--- a/commands/version.go
+++ b/commands/version.go
@@ -9,7 +9,7 @@ import (
 type VersionCmd struct{}
 
 // Run executes the `login` command
-func (a *VersionCmd) Run() (err error) {
+func (c *VersionCmd) Run() (err error) {
 	fmt.Printf("%s (%s-%s)\n", "0.0.1", runtime.GOOS, runtime.GOARCH)
 	return err
 }


### PR DESCRIPTION
As identified in the review of #2, we were referring to receivers as `a` for `app`. 

This PR changes it to `c` for `command`, to make the naming simpler and consistent.