### PR TITLE
Bugfix: create directory for consent

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -208,6 +208,11 @@ func WriteConsent(consent bool) (err error) {
 	if err != nil {
 		return err
 	}
+	consentPathBasedir := filepath.Dir(consentPath)
+	err = os.MkdirAll(consentPathBasedir, os.ModeDir+0700)
+	if err != nil {
+		return err
+	}
 	err = ioutil.WriteFile(consentPath, json, 0644)
 	if err != nil {
 		return err

--- a/analytics/consent_test.go
+++ b/analytics/consent_test.go
@@ -66,20 +66,31 @@ func TestConsentPromptsForConsentIfConsentNotRecorded(t *testing.T) {
 func TestConsentPromptForConsent(t *testing.T) {
 	assert := assert.New(t)
 
-	// Setup
-	var outbuf bytes.Buffer
-	out = &outbuf
+	var testCases = []struct {
+		input  string
+		retval bool
+	}{
+		{"y\n", true},
+		{"n\n", false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			// Setup
+			var outbuf bytes.Buffer
+			out = &outbuf
 
-	var inbuf bytes.Buffer
-	inbuf.Write([]byte("y\n"))
-	in = &inbuf
+			var inbuf bytes.Buffer
+			inbuf.Write([]byte(tc.input))
+			in = &inbuf
 
-	// Invoke
-	c, err := PromptForConsent()
+			// Invoke
+			c, err := PromptForConsent()
 
-	// Test
-	assert.NoError(err)
-	assert.True(c)
+			// Test
+			assert.NoError(err)
+			assert.Equal(c, tc.retval)
+		})
+	}
 }
 
 func TestConsentPromptRecordsConsent(t *testing.T) {

--- a/analytics/consent_test.go
+++ b/analytics/consent_test.go
@@ -63,11 +63,31 @@ func TestConsentPromptsForConsentIfConsentNotRecorded(t *testing.T) {
 	assert.Contains(outbuf.String(), "[y/N]")
 }
 
+func TestConsentPromptForConsent(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup
+	var outbuf bytes.Buffer
+	out = &outbuf
+
+	var inbuf bytes.Buffer
+	inbuf.Write([]byte("y\n"))
+	in = &inbuf
+
+	// Invoke
+	c, err := PromptForConsent()
+
+	// Test
+	assert.NoError(err)
+	assert.True(c)
+}
+
 func TestConsentPromptRecordsConsent(t *testing.T) {
 	assert := assert.New(t)
 
 	// Setup
 	consentPath = newConsentTempfile(t)
+	assert.False(IsConsentRecorded())
 
 	var outbuf bytes.Buffer
 	out = &outbuf


### PR DESCRIPTION
Users testing the prerelease candidate have reported that the consent prompt fails, rendering `sectionctl` unusable. 

This PR ensures all the directories are created underneath where the consent file lives. 

It also includes some minor refactoring, so the prompt can be tested in isolation of writing the consent file to disk. 