### PR TITLE
Improve deploy subcommand debug statements

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -69,6 +69,9 @@ func (c *DeployCmd) Run() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to pack files: %v", err)
 	}
+	if c.Debug {
+		fmt.Println("[debug] Temporary tarball path:", tempFile.Name())
+	}
 	stat, err := tempFile.Stat()
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("Could not get stat for file '%s', got error '%s'", tempFile.Name(), err.Error()))

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -119,8 +119,8 @@ func (c *DeployCmd) Run() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to decode response %v", err)
 	}
-	svcURL := c.ApertureURL + fmt.Sprintf(c.EnvUpdatePathFmt, c.AccountID, c.AppID, "production")
-	err = triggerUpdate(c.AccountID, c.AppID, response.PayloadID, svcURL, client)
+	serviceURL := c.ApertureURL + fmt.Sprintf(c.EnvUpdatePathFmt, c.AccountID, c.AppID, "production")
+	err = triggerUpdate(response.PayloadID, serviceURL, client)
 	if err != nil {
 		if c.Debug {
 			fmt.Println("[debug] Request URL:", serviceURL)
@@ -217,7 +217,7 @@ type PayloadValue struct {
 	ID string `json:"section_payload_id"`
 }
 
-func triggerUpdate(accountID, appID int, payloadID, serviceURL string, c *http.Client) error {
+func triggerUpdate(payloadID, serviceURL string, client *http.Client) error {
 	var b bytes.Buffer
 	payload := []struct {
 		Op    string       `json:"op"`
@@ -249,7 +249,7 @@ func triggerUpdate(accountID, appID int, payloadID, serviceURL string, c *http.C
 		return fmt.Errorf("unable to read credentials: %s", err)
 	}
 	req.SetBasicAuth(username, password)
-	resp, err := c.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to execute trigger request: %v", err)
 	}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -255,7 +255,7 @@ func triggerUpdate(accountID, appID int, payloadID, serviceURL string, c *http.C
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 && resp.StatusCode != 204 {
-		return fmt.Errorf("trigger update failed with status %s", resp.Status)
+		return fmt.Errorf("trigger update failed with status: %s", resp.Status)
 	}
 	return nil
 }

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -49,9 +49,9 @@ func (c *DeployCmd) Run() (err error) {
 	ignores := []string{".lint/", ".git/"}
 	files, err := BuildFilelist(c.Directory, ignores)
 	if c.Debug {
-		fmt.Println("Archiving files:")
+		fmt.Println("[debug] Archiving files:")
 		for _, file := range files {
-			fmt.Println(file)
+			fmt.Println("[debug]", file)
 		}
 	}
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -64,7 +64,7 @@ func (c *DeployCmd) Run() (err error) {
 	}
 	fmt.Printf("Packaging app in: %s\n", dir)
 
-	tempFile, err := ioutil.TempFile("", "section")
+	tempFile, err := ioutil.TempFile("", "sectionctl-deploy")
 	if err != nil {
 		return fmt.Errorf("couldn't create a temp file: %v", err)
 	}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -42,10 +42,6 @@ type UploadResponse struct {
 
 // Run deploys an app to Section's edge
 func (c *DeployCmd) Run() (err error) {
-	if c.Debug {
-		fmt.Println("Server URL:", c.ServerURL.String())
-	}
-
 	ignores := []string{".lint/", ".git/"}
 	files, err := BuildFilelist(c.Directory, ignores)
 	if c.Debug {
@@ -99,6 +95,10 @@ func (c *DeployCmd) Run() (err error) {
 	}
 	req.SetBasicAuth(username, password)
 
+	if c.Debug {
+		fmt.Println("[debug] Request URL:", req.URL)
+	}
+
 	client := &http.Client{
 		Timeout: c.Timeout,
 	}
@@ -119,7 +119,10 @@ func (c *DeployCmd) Run() (err error) {
 	svcURL := c.ApertureURL + fmt.Sprintf(c.EnvUpdatePathFmt, c.AccountID, c.AppID, "production")
 	err = triggerUpdate(c.AccountID, c.AppID, response.PayloadID, svcURL, client)
 	if err != nil {
-		return fmt.Errorf("failed to trigger app update %v", err)
+		if c.Debug {
+			fmt.Println("[debug] Request URL:", serviceURL)
+		}
+		return fmt.Errorf("failed to trigger app update: %v", err)
 	}
 
 	fmt.Println("Done.")

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -86,7 +86,7 @@ func (c *DeployCmd) Run() (err error) {
 		return fmt.Errorf("unable to seek to beginning of tarball: %s", err)
 	}
 
-	fmt.Printf("Pushing %d bytes...\n", stat.Size())
+	fmt.Printf("Pushing %dMB...\n", stat.Size()/1024)
 
 	req, err := newFileUploadRequest(c, tempFile)
 	if err != nil {


### PR DESCRIPTION
- Prefix all existing debug messages with `[debug]`, to improve readability
- Make it clearer to the user when errors are being wrapped
- Display bytes transferred in a unit that's more readable to the user
- Emit the request URLs explicitly every time the request is being made, instead of just printing user input
- Print the path to the temporary tarball