### PR TITLE
Add even more debug messages to deploy subcommand

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -266,7 +266,7 @@ func triggerUpdate(payloadID, serviceURL string, client *http.Client) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 && resp.StatusCode != 204 {
-		return fmt.Errorf("trigger update failed with status: %s", resp.Status)
+		return fmt.Errorf("trigger update failed with status: %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
 	}
 	return nil
 }

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -249,6 +249,17 @@ func triggerUpdate(payloadID, serviceURL string, client *http.Client) error {
 		return fmt.Errorf("unable to read credentials: %s", err)
 	}
 	req.SetBasicAuth(username, password)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("filepath", "nodejs/.section-external-source.json")
+
+	if c.Debug {
+		for k, vs := range req.Header {
+			for _, v := range vs {
+				fmt.Printf("[debug] Header: %s: %v\n", k, v)
+			}
+		}
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to execute trigger request: %v", err)


### PR DESCRIPTION
- Print all the headers we're sending
- Print the JSON payload
- Print the Aperture transaction ID on request failure