### PR TITLE
Strip leading path from tarball files

### DIFF
--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -89,8 +89,6 @@ func TestCommandsDeployCreateTarballAlwaysPutsAppAtRoot(t *testing.T) {
 
 			err = os.Chdir(tc.cwd)
 			assert.NoError(err)
-			dir, err := os.Getwd()
-			assert.NoError(err)
 
 			// Build the file list
 			paths, err := BuildFilelist(tc.target, ignores)

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -96,6 +96,7 @@ func TestCommandsDeployCreateTarballAlwaysPutsAppAtRoot(t *testing.T) {
 
 			// Build the file list
 			paths, err := BuildFilelist(tc.target, ignores)
+			assert.NoError(err)
 
 			// Create the tarball
 			err = CreateTarball(tempFile, paths)

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -87,6 +87,10 @@ func TestCommandsDeployCreateTarballAlwaysPutsAppAtRoot(t *testing.T) {
 			tempFile, err := ioutil.TempFile("", "sectionctl-deploy")
 			assert.NoError(err)
 
+			// Record where we were at the beginning of the test
+			owd, err := os.Getwd()
+			assert.NoError(err)
+
 			err = os.Chdir(tc.cwd)
 			assert.NoError(err)
 
@@ -109,6 +113,10 @@ func TestCommandsDeployCreateTarballAlwaysPutsAppAtRoot(t *testing.T) {
 			assert.NoError(err)
 			path := filepath.Join(tempDir, "package.json")
 			_, err = os.Stat(path)
+			assert.NoError(err)
+
+			// Change back to where we were at the beginning of the test
+			err = os.Chdir(owd)
 			assert.NoError(err)
 		})
 	}


### PR DESCRIPTION
**Before:**

Running `sectionctl deploy --directory path/to/dir` would create a tarball with files prefixed with `path/to/dir`.

**After:** 

Running `sectionctl deploy --directory path/to/dir` creates a tarball with the leading directory stripped from filenames.
