### PR TITLE
Display the size of the artifact in debug logs

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -127,7 +127,7 @@ func (c *DeployCmd) Run() (err error) {
 
 	artifactSizeMB := stat.Size() / 1024 / 1024
 	if c.Debug {
-		fmt.Println("[debug] Upload artifact is %dMB (%d bytes) large", artifactSizeMB, stat.Size())
+		fmt.Printf("[debug] Upload artifact is %dMB (%d bytes) large", artifactSizeMB, stat.Size())
 	}
 	s.Suffix = fmt.Sprintf(" Uploading app (%dMB)...", artifactSizeMB)
 	s.Start()

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -125,7 +125,11 @@ func (c *DeployCmd) Run() (err error) {
 		fmt.Println("[debug] Request URL:", req.URL)
 	}
 
-	s.Suffix = fmt.Sprintf(" Uploading app (%dMB)...", stat.Size()/1024/1024)
+	artifactSizeMB := stat.Size() / 1024 / 1024
+	if c.Debug {
+		fmt.Println("[debug] Upload artifact is %dMB (%d bytes) large", artifactSizeMB, stat.Size())
+	}
+	s.Suffix = fmt.Sprintf(" Uploading app (%dMB)...", artifactSizeMB)
 	s.Start()
 	client := &http.Client{
 		Timeout: c.Timeout,


### PR DESCRIPTION
Because of the way the spinner works, when the message clears, there's no output showing the size of the artifact we've uploaded.

This adds debug output that will show even when the spinner clears.