### PR TITLE
Add ability to renew certs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -37,6 +37,8 @@ func request(method string, u url.URL, body io.Reader) (resp *http.Response, err
 
 	ua := fmt.Sprintf("sectionctl (%s; %s-%s)", version.Version, runtime.GOARCH, runtime.GOOS)
 	req.Header.Set("User-Agent", ua)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
 
 	username, password, err := auth.GetCredential(u.Host)
 	if err != nil {

--- a/api/domains.go
+++ b/api/domains.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+/*
+{
+	  "issued": true,
+	    "message": "The certificate has been renewed",
+		  "expiry": "2021-01-26T12:31:38.000Z",
+		    "renewFrom": "2020-12-27T12:31:38.000Z"
+		}
+*/
+
+// RenewCertResponse represents an API response to POST /account/{accountId}/domain/{hostName}/renewCertificate
+type RenewCertResponse struct {
+	Issued    bool      `json:"issued"`
+	Message   string    `json:"message"`
+	Expiry    time.Time `json:"expiry"`
+	RenewFrom time.Time `json:"renewFrom"`
+}
+
+// DomainsRenewCert handles renewing a certificate for a given account and domain.
+func DomainsRenewCert(accountID int, hostname string) (r RenewCertResponse, err error) {
+	u := BaseURL()
+	u.Path += fmt.Sprintf("/account/%d/domain/%s/renewCertificate", accountID, hostname)
+
+	resp, err := request(http.MethodPost, u, nil)
+	if err != nil {
+		return r, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return r, fmt.Errorf("request failed with status %s", resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return r, err
+	}
+
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		return r, err
+	}
+
+	return r, err
+}

--- a/commands/certs.go
+++ b/commands/certs.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/section/sectionctl/api"
+	"github.com/section/sectionctl/api/auth"
+)
+
+// CertsCmd manages certificates on Section
+type CertsCmd struct {
+	Renew CertsRenewCmd `cmd help:"Renew a certificate for a domain."`
+}
+
+// CertsRenewCmd handles renewing a certificate
+type CertsRenewCmd struct {
+	AccountID int    `required short:"a"`
+	Hostname  string `required`
+}
+
+// Run executes the command
+func (c *CertsRenewCmd) Run() (err error) {
+	err = auth.Setup(api.PrefixURI.Host)
+	if err != nil {
+		return err
+	}
+
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(os.Stderr))
+	s.Suffix = fmt.Sprintf(" Renewing cert for %s", c.Hostname)
+	s.Start()
+	time.Sleep(2 * time.Second)
+
+	resp, err := api.DomainsRenewCert(c.AccountID, c.Hostname)
+	if err != nil {
+		s.Stop()
+		return err
+	}
+
+	fmt.Printf("\nSuccess: %s\n", resp.Message)
+
+	return err
+}

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -16,6 +16,7 @@ var CLI struct {
 	Login            commands.LoginCmd    `cmd help:"Authenticate to Section's API."`
 	Accounts         commands.AccountsCmd `cmd help:"Manage accounts on Section"`
 	Apps             commands.AppsCmd     `cmd help:"Manage apps on Section"`
+	Certs            commands.CertsCmd    `cmd help:"Manage certificates on Section"`
 	Deploy           commands.DeployCmd   `cmd help:"Deploy an app to Section"`
 	Version          commands.VersionCmd  `cmd help:"Print sectionctl version"`
 	SectionAPIPrefix *url.URL             `default:"https://aperture.section.io" env:"SECTION_API_PREFIX"`


### PR DESCRIPTION
Looks like this: 

```
$ sectionctl certs renew --account-id 2087 --hostname dax2b0mjmn4fbhvbbttr.section.dev
⠋ Renewing cert for dax2b0mjmn4fbhvbbttr.section.dev
Success: Renewal not required yet
```