### PR TITLE
Output the transaction ID on error, to so user can correlate error to logs

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -30,7 +30,7 @@ func Accounts() (as []Account, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return as, fmt.Errorf("request failed with status %s", resp.Status)
+		return as, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/account.go
+++ b/api/account.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sort"

--- a/api/account.go
+++ b/api/account.go
@@ -30,7 +30,7 @@ func Accounts() (as []Account, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return as, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
+		return as, prettyTxIDError(resp)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/api.go
+++ b/api/api.go
@@ -52,3 +52,11 @@ func request(method string, u url.URL, body io.Reader) (resp *http.Response, err
 	}
 	return resp, err
 }
+
+// prettyTxIDError creates a support friendly error message with an transaction ID
+func prettyTxIDError(resp *http.Response) error {
+	if len(resp.Header["Aperture-Tx-Id"]) > 0 {
+		return fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
+	}
+	return fmt.Errorf("request failed with status %s", resp.Status)
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -54,3 +54,29 @@ func TestAPIClientSetsUserAgent(t *testing.T) {
 	// Test
 	assert.Regexp("^sectionctl (.+)$", userAgent)
 }
+
+func TestPrettyTxIDErrorPrintsApertureTxID(t *testing.T) {
+	assert := assert.New(t)
+
+	// Invoke
+	resp := http.Response{Status: "500 Internal Server Error", Header: map[string][]string{"Aperture-Tx-Id": []string{"12345"}}}
+	err := prettyTxIDError(&resp)
+
+	// Test
+	assert.Error(err)
+	assert.Regexp("transaction ID", err)
+	assert.Regexp(resp.Header["Aperture-Tx-Id"][0], err)
+}
+
+func TestPrettyTxIDErrorHandlesNoApertureTxIDHeader(t *testing.T) {
+	assert := assert.New(t)
+
+	// Invoke
+	resp := http.Response{Status: "500 Internal Server Error"}
+	assert.NotPanics(func() { prettyTxIDError(&resp) })
+	err := prettyTxIDError(&resp)
+
+	// Test
+	assert.Error(err)
+	assert.NotRegexp("transaction ID", err)
+}

--- a/api/applications.go
+++ b/api/applications.go
@@ -51,7 +51,7 @@ func Application(accountID int, applicationID int) (a App, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return a, fmt.Errorf("request failed with status %s", resp.Status)
+		return a, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -93,7 +93,7 @@ func ApplicationEnvironments(accountID int, applicationID int) (es []Environment
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return es, fmt.Errorf("request failed with status %s", resp.Status)
+		return es, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -120,7 +120,7 @@ func ApplicationEnvironmentStack(accountID int, applicationID int, environmentNa
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return s, fmt.Errorf("request failed with status %s", resp.Status)
+		return s, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/applications.go
+++ b/api/applications.go
@@ -51,7 +51,7 @@ func Application(accountID int, applicationID int) (a App, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return a, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
+		return a, prettyTxIDError(resp)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -93,7 +93,7 @@ func ApplicationEnvironments(accountID int, applicationID int) (es []Environment
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return es, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
+		return es, prettyTxIDError(resp)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -120,7 +120,7 @@ func ApplicationEnvironmentStack(accountID int, applicationID int, environmentNa
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return s, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
+		return s, prettyTxIDError(resp)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/domains.go
+++ b/api/domains.go
@@ -37,7 +37,7 @@ func DomainsRenewCert(accountID int, hostname string) (r RenewCertResponse, err 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return r, fmt.Errorf("request failed with status %s", resp.Status)
+		return r, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/domains.go
+++ b/api/domains.go
@@ -37,7 +37,7 @@ func DomainsRenewCert(accountID int, hostname string) (r RenewCertResponse, err 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return r, fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
+		return r, prettyTxIDError(resp)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Output the value of the `Aperture-Tx-Id` header, so the user has something to provide to Section support when lodging a support ticket. 