### PR TITLE
Add a check for presence of server.conf when deploying Node.js apps

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -183,6 +183,11 @@ func IsValidNodeApp(dir string) (errs []error) {
 		}
 	}
 
+	serverConfPath := filepath.Join(dir, "server.conf")
+	if _, err := os.Stat(serverConfPath); os.IsNotExist(err) {
+		errs = append(errs, fmt.Errorf("%s is not a file (see https://github.com/section/nodejs-example/blob/master/server.conf)", serverConfPath))
+	}
+
 	return errs
 }
 


### PR DESCRIPTION
Catch a common deployment error. 