### PR TITLE
Add ability to set credentials via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ sectionctl install-completions
 
 ### Using `sectionctl` in CI/CD
 
-You can set credentials via the `SECTION_USERNAME` and `SECTION_PASSWORD` environment variables:
+You can set credentials via the `SECTION_USERNAME` and `SECTION_TOKEN` environment variables:
 
-```
-SECTION_USERNAME=me@domain.example SECTION_PASSWORD=s3cr3t sectionctl accounts list
+``` bash
+SECTION_USERNAME=me@domain.example SECTION_TOKEN=s3cr3t sectionctl accounts list
 ```
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Install bash shell completions with:
 sectionctl install-completions
 ```
 
+### Using `sectionctl` in CI/CD
+
+You can set credentials via the `SECTION_USERNAME` and `SECTION_PASSWORD` environment variables:
+
+```
+SECTION_USERNAME=me@domain.example SECTION_PASSWORD=s3cr3t sectionctl accounts list
+```
+
 ## Installing
 
 The easiest way to install `sectionctl` is by downloading [the latest release](https://github.com/section/sectionctl/releases/latest) and putting it on your `PATH`.

--- a/api/api.go
+++ b/api/api.go
@@ -16,6 +16,10 @@ var (
 	// PrefixURI is the root of the Section API
 	PrefixURI = &url.URL{Scheme: "https", Host: "aperture.section.io"}
 	timeout   = 20 * time.Second
+	// Username is the username for authenticating to the Section API
+	Username string
+	// Token is the token for authenticating to the Section API
+	Token string
 )
 
 // BaseURL returns a URL for building requests on
@@ -40,11 +44,13 @@ func request(method string, u url.URL, body io.Reader) (resp *http.Response, err
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
 
-	username, password, err := auth.GetCredential(u.Host)
-	if err != nil {
-		return resp, err
+	if Username == "" || Token == "" {
+		Username, Token, err = auth.GetCredential(u.Host)
+		if err != nil {
+			return resp, err
+		}
 	}
-	req.SetBasicAuth(username, password)
+	req.SetBasicAuth(Username, Token)
 
 	resp, err = client.Do(req)
 	if err != nil {

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -14,30 +14,39 @@ import (
 )
 
 // CLI exposes all the subcommands available
-var CLI struct {
+type CLI struct {
 	Login              commands.LoginCmd            `cmd help:"Authenticate to Section's API."`
 	Accounts           commands.AccountsCmd         `cmd help:"Manage accounts on Section"`
 	Apps               commands.AppsCmd             `cmd help:"Manage apps on Section"`
 	Certs              commands.CertsCmd            `cmd help:"Manage certificates on Section"`
 	Deploy             commands.DeployCmd           `cmd help:"Deploy an app to Section"`
 	Version            commands.VersionCmd          `cmd help:"Print sectionctl version"`
+	SectionUsername    string                       `env:"SECTION_USERNAME" help:"Username for API auth"`
+	SectionToken       string                       `env:"SECTION_TOKEN" help:"Secret token for API auth"`
 	SectionAPIPrefix   *url.URL                     `default:"https://aperture.section.io" env:"SECTION_API_PREFIX"`
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"install shell completions"`
 }
 
+func bootstrap(c CLI) {
+	api.PrefixURI = c.SectionAPIPrefix
+	api.Username = c.SectionUsername
+	api.Token = c.SectionToken
+}
+
 func main() {
 	// Handle completion requests
-	parser := kong.Must(&CLI, kong.Name("sectionctl"), kong.UsageOnError())
+	var cli CLI
+	parser := kong.Must(&cli, kong.Name("sectionctl"), kong.UsageOnError())
 	kongplete.Complete(parser,
 		kongplete.WithPredictor("file", complete.PredictFiles("*")),
 	)
 
-	ctx := kong.Parse(&CLI,
+	ctx := kong.Parse(&cli,
 		kong.Description("CLI to interact with Section."),
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{Tree: true}),
 	)
-	api.PrefixURI = CLI.SectionAPIPrefix
+	bootstrap(cli)
 	analytics.LogInvoke(ctx)
 	err := ctx.Run()
 	if err != nil {


### PR DESCRIPTION
Allows credentials to be set via the `SECTION_USERNAME` and `SECTION_TOKEN` environment variables. 

Closes #33.