### PR TITLE
Refactor HTTP requests made in `sectionctl deploy` into the API client

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -20,6 +20,8 @@ var (
 	Username string
 	// Token is the token for authenticating to the Section API
 	Token string
+	// Debug toggles whether extra information is emitted from requests/responses
+	Debug bool
 )
 
 // BaseURL returns a URL for building requests on
@@ -57,6 +59,14 @@ func request(method string, u url.URL, body io.Reader, headers ...map[string][]s
 	}
 	req.SetBasicAuth(Username, Token)
 
+	if Debug {
+		fmt.Println("[DEBUG] Request URL:", req.URL)
+		for k, vs := range req.Header {
+			for _, v := range vs {
+				fmt.Printf("[DEBUG] Header: %s: %v\n", k, v)
+			}
+		}
+	}
 	resp, err = client.Do(req)
 	if err != nil {
 		return resp, err

--- a/api/api.go
+++ b/api/api.go
@@ -31,7 +31,7 @@ func BaseURL() (u url.URL) {
 	return u
 }
 
-func request(method string, u url.URL, body io.Reader, headers ...map[string][]string) (resp *http.Response, err error) {
+func request(method string, u url.URL, body io.Reader, headers ...http.Header) (resp *http.Response, err error) {
 	client := &http.Client{
 		Timeout: timeout,
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -31,6 +31,9 @@ func BaseURL() (u url.URL) {
 	return u
 }
 
+// request does the heavy lifting of making requests to the Section API.
+//
+// You can pass 0 or more headers, and keys in the later headers will override earlier passed headers.
 func request(method string, u url.URL, body io.Reader, headers ...http.Header) (resp *http.Response, err error) {
 	client := &http.Client{
 		Timeout: timeout,
@@ -45,8 +48,8 @@ func request(method string, u url.URL, body io.Reader, headers ...http.Header) (
 	req.Header.Set("User-Agent", ua)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
-	if len(headers) == 1 {
-		for h, v := range headers[0] {
+	for i := range headers {
+		for h, v := range headers[i] {
 			req.Header[h] = v
 		}
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -29,7 +29,7 @@ func BaseURL() (u url.URL) {
 	return u
 }
 
-func request(method string, u url.URL, body io.Reader) (resp *http.Response, err error) {
+func request(method string, u url.URL, body io.Reader, headers ...map[string][]string) (resp *http.Response, err error) {
 	client := &http.Client{
 		Timeout: timeout,
 	}
@@ -43,6 +43,11 @@ func request(method string, u url.URL, body io.Reader) (resp *http.Response, err
 	req.Header.Set("User-Agent", ua)
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
+	if len(headers) == 1 {
+		for h, v := range headers[0] {
+			req.Header[h] = v
+		}
+	}
 
 	if Username == "" || Token == "" {
 		Username, Token, err = auth.GetCredential(u.Host)

--- a/api/api.go
+++ b/api/api.go
@@ -51,13 +51,15 @@ func request(method string, u url.URL, body io.Reader, headers ...map[string][]s
 		}
 	}
 
-	if Username == "" || Token == "" {
-		Username, Token, err = auth.GetCredential(u.Host)
+	user := Username
+	token := Token
+	if user == "" || token == "" {
+		user, token, err = auth.GetCredential(u.Host)
 		if err != nil {
 			return resp, err
 		}
 	}
-	req.SetBasicAuth(Username, Token)
+	req.SetBasicAuth(user, token)
 
 	if Debug {
 		fmt.Println("[DEBUG] Request URL:", req.URL)

--- a/api/applications.go
+++ b/api/applications.go
@@ -179,6 +179,9 @@ func ApplicationEnvironmentModuleUpdate(accountID int, applicationID int, env st
 	if err != nil {
 		return fmt.Errorf("failed to encode json payload: %v", err)
 	}
+	if Debug {
+		fmt.Printf("[DEBUG] JSON payload: %s\n", b)
+	}
 	headers := map[string][]string{"filepath": []string{filePath}}
 	resp, err := request(http.MethodPatch, u, bytes.NewBuffer(b), headers)
 	if err != nil {

--- a/api/applications.go
+++ b/api/applications.go
@@ -196,7 +196,8 @@ func ApplicationEnvironmentModuleUpdate(accountID int, applicationID int, env st
 	if resp.StatusCode != 200 && resp.StatusCode != 204 {
 		var objmap map[string]interface{}
 		if err := json.Unmarshal(body, &objmap); err != nil {
-			return fmt.Errorf("unable to decode error message: %s", err)
+			nerr := fmt.Errorf("unable to decode error message: %s", err)
+			return fmt.Errorf("trigger update failed with status: %s and transaction ID %s\n. Error received: \n%s", resp.Status, resp.Header["Aperture-Tx-Id"][0], nerr)
 		}
 		return fmt.Errorf("trigger update failed with status: %s and transaction ID %s\n. Error received: \n%s", resp.Status, resp.Header["Aperture-Tx-Id"][0], objmap["message"])
 	}

--- a/api/applications.go
+++ b/api/applications.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -160,4 +161,41 @@ func Applications(accountID int) (as []App, err error) {
 		return as, err
 	}
 	return as, err
+}
+
+// EnvironmentUpdateCommand is a blah
+type EnvironmentUpdateCommand struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+}
+
+// ApplicationEnvironmentModuleUpdate updates a module's configuration
+func ApplicationEnvironmentModuleUpdate(accountID int, applicationID int, env string, filePath string, up EnvironmentUpdateCommand) (err error) {
+	u := BaseURL()
+	u.Path += fmt.Sprintf("/account/%d/application/%d/environment/%s/update", accountID, applicationID, "production")
+
+	b, err := json.Marshal(up)
+	if err != nil {
+		return fmt.Errorf("failed to encode json payload: %v", err)
+	}
+	headers := map[string][]string{"filepath": []string{filePath}}
+	resp, err := request(http.MethodPatch, u, bytes.NewBuffer(b), headers)
+	if err != nil {
+		return fmt.Errorf("failed to execute trigger request: %v", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("could not read response body: %s", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 && resp.StatusCode != 204 {
+		var objmap map[string]interface{}
+		if err := json.Unmarshal(body, &objmap); err != nil {
+			return fmt.Errorf("unable to decode error message: %s", err)
+		}
+		return fmt.Errorf("trigger update failed with status: %s and transaction ID %s\n. Error received: \n%s", resp.Status, resp.Header["Aperture-Tx-Id"][0], objmap["message"])
+	}
+	return nil
 }

--- a/api/applications_test.go
+++ b/api/applications_test.go
@@ -1,0 +1,39 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/section/sectionctl/api/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplicationEnvironmentModuleUpdateErrorsIfRequestFails(t *testing.T) {
+	assert := assert.New(t)
+
+	// Setup
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _, ok := r.BasicAuth()
+		assert.True(ok)
+		w.Header().Add("Aperture-Tx-Id", "400400400400.400400")
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	url, err := url.Parse(ts.URL)
+	assert.NoError(err)
+	PrefixURI = url
+
+	auth.CredentialPath = newCredentialTempfile(t)
+	endpoint := url.Host
+	username := "hello"
+	password := "s3cr3t"
+	auth.WriteCredential(endpoint, username, password)
+
+	// Invoke
+	up := EnvironmentUpdateCommand{Op: "replace", Value: map[string]string{"hello": "world"}}
+	err = ApplicationEnvironmentModuleUpdate(1, 1, "production", "hello/world.json", up)
+
+	// Test
+	assert.Error(err)
+}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/section/sectionctl/api"
 	"github.com/section/sectionctl/api/auth"
 )
 
@@ -40,6 +41,11 @@ type DeployCmd struct {
 // UploadResponse represents the response from a request to the upload service.
 type UploadResponse struct {
 	PayloadID string `json:"payloadID"`
+}
+
+// PayloadValue represents the value of a trigger update payload.
+type PayloadValue struct {
+	ID string `json:"section_payload_id"`
 }
 
 // Run deploys an app to Section's edge
@@ -158,13 +164,15 @@ func (c *DeployCmd) Run() (err error) {
 	}
 	s.Suffix = " Deploying app..."
 	s.Start()
-	serviceURL := c.ApertureURL + fmt.Sprintf(c.EnvUpdatePathFmt, c.AccountID, c.AppID, "production")
-	err = triggerUpdate(c, response.PayloadID, serviceURL, client)
+	up := api.EnvironmentUpdateCommand{
+		Op: "replace",
+		Value: PayloadValue{
+			ID: response.PayloadID,
+		},
+	}
+	err = api.ApplicationEnvironmentModuleUpdate(c.AccountID, c.AppID, "production", "nodejs/.section-external-source.json", up)
 	s.Stop()
 	if err != nil {
-		if c.Debug {
-			fmt.Println("[debug] Request URL:", serviceURL)
-		}
 		return fmt.Errorf("failed to trigger app update: %v", err)
 	}
 
@@ -284,78 +292,6 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer, prefix string) e
 		}
 	}
 
-	return nil
-}
-
-// PayloadValue represents the value of a trigger update payload.
-type PayloadValue struct {
-	ID string `json:"section_payload_id"`
-}
-
-func triggerUpdate(c *DeployCmd, payloadID, serviceURL string, client *http.Client) error {
-	payload := []struct {
-		Op    string       `json:"op"`
-		Path  string       `json:"path"`
-		Value PayloadValue `json:"value"`
-	}{
-		{
-			Op: "replace",
-			Value: PayloadValue{
-				ID: payloadID,
-			},
-		},
-	}
-
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("failed to encode json payload: %v", err)
-	}
-	if c.Debug {
-		fmt.Printf("[debug] JSON payload: %s\n", b)
-	}
-	req, err := http.NewRequest(http.MethodPatch, serviceURL, bytes.NewBuffer(b))
-	if err != nil {
-		return fmt.Errorf("failed to create trigger request: %v", err)
-	}
-	u, err := url.Parse(serviceURL)
-	if err != nil {
-		return fmt.Errorf("failed to build URL for triggerUpdate action: %v", err)
-	}
-	username, password, err := auth.GetCredential(u.Host)
-	if err != nil {
-		return fmt.Errorf("unable to read credentials: %s", err)
-	}
-	req.SetBasicAuth(username, password)
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Accept", "application/json")
-	req.Header.Add("filepath", "nodejs/.section-external-source.json")
-
-	if c.Debug {
-		for k, vs := range req.Header {
-			for _, v := range vs {
-				fmt.Printf("[debug] Header: %s: %v\n", k, v)
-			}
-		}
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to execute trigger request: %v", err)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("could not read response body: %s", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 && resp.StatusCode != 204 {
-		var objmap map[string]interface{}
-		if err := json.Unmarshal(body, &objmap); err != nil {
-			return fmt.Errorf("unable to decode error message: %s", err)
-		}
-		return fmt.Errorf("trigger update failed with status: %s and transaction ID %s\n. Error received: \n%s", resp.Status, resp.Header["Aperture-Tx-Id"][0], objmap["message"])
-	}
 	return nil
 }
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -27,15 +27,13 @@ const MaxFileSize = 1073741824 // 1GB
 
 // DeployCmd handles deploying an app to Section.
 type DeployCmd struct {
-	AccountID        int `required`
-	AppID            int `required`
-	Debug            bool
-	Directory        string        `default:"."`
-	ServerURL        *url.URL      `default:"https://aperture.section.io/new/code_upload/v1/upload"`
-	ApertureURL      string        `default:"https://aperture.section.io/api/v1"`
-	EnvUpdatePathFmt string        `default:"/account/%d/application/%d/environment/%s/update"`
-	Timeout          time.Duration `default:"300s"`
-	SkipDelete       bool          `help:"Skip delete of temporary tarball created to upload app"`
+	AccountID  int `required`
+	AppID      int `required`
+	Debug      bool
+	Directory  string        `default:"."`
+	ServerURL  *url.URL      `default:"https://aperture.section.io/new/code_upload/v1/upload"`
+	Timeout    time.Duration `default:"300s"`
+	SkipDelete bool          `help:"Skip delete of temporary tarball created to upload app"`
 }
 
 // UploadResponse represents the response from a request to the upload service.

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -212,7 +212,7 @@ func TestCommandsDeployUploadsTarball(t *testing.T) {
 		body      []byte
 		accountID int
 		file      []byte
-		headers   map[string]string
+		header    http.Header
 	}
 	var uploadReq req
 	var triggerUpdateReq req
@@ -247,7 +247,7 @@ func TestCommandsDeployUploadsTarball(t *testing.T) {
 			b, err := ioutil.ReadAll(r.Body)
 			assert.NoError(err)
 			triggerUpdateReq.body = b
-			triggerUpdateReq.headers = map[string]string{"filepath": r.Header.Get("filepath")}
+			triggerUpdateReq.header = r.Header
 			w.WriteHeader(http.StatusOK)
 		default:
 			assert.FailNow("unhandled URL %s", r.URL.Path)
@@ -293,9 +293,7 @@ func TestCommandsDeployUploadsTarball(t *testing.T) {
 	assert.Equal(username, triggerUpdateReq.username)
 	assert.Equal(password, triggerUpdateReq.password)
 	assert.NotZero(len(triggerUpdateReq.body))
-	if assert.NotEmpty(triggerUpdateReq.headers["filepath"]) {
-		assert.Equal(triggerUpdateReq.headers["filepath"], "nodejs/.section-external-source.json")
-	}
+	assert.Equal(triggerUpdateReq.header.Get("filepath"), "nodejs/.section-external-source.json")
 	var up api.EnvironmentUpdateCommand
 	err = json.Unmarshal(triggerUpdateReq.body, &up)
 	assert.NoError(err)

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -270,12 +270,10 @@ func TestCommandsDeployUploadsTarball(t *testing.T) {
 
 	// Invoke
 	c := DeployCmd{
-		Directory:        dir,
-		ServerURL:        url,
-		ApertureURL:      url.String() + "/api/v1",
-		AccountID:        100,
-		AppID:            200,
-		EnvUpdatePathFmt: "/account/%d/application/%d/environment/%s/update",
+		Directory: dir,
+		ServerURL: url,
+		AccountID: 100,
+		AppID:     200,
 	}
 	err = c.Run()
 

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -21,6 +21,7 @@ type CLI struct {
 	Certs              commands.CertsCmd            `cmd help:"Manage certificates on Section"`
 	Deploy             commands.DeployCmd           `cmd help:"Deploy an app to Section"`
 	Version            commands.VersionCmd          `cmd help:"Print sectionctl version"`
+	Debug              bool                         `env:"DEBUG" help:"Enable debug output"`
 	SectionUsername    string                       `env:"SECTION_USERNAME" help:"Username for API auth"`
 	SectionToken       string                       `env:"SECTION_TOKEN" help:"Secret token for API auth"`
 	SectionAPIPrefix   *url.URL                     `default:"https://aperture.section.io" env:"SECTION_API_PREFIX"`
@@ -28,6 +29,7 @@ type CLI struct {
 }
 
 func bootstrap(c CLI) {
+	api.Debug = c.Debug
 	api.PrefixURI = c.SectionAPIPrefix
 	api.Username = c.SectionUsername
 	api.Token = c.SectionToken


### PR DESCRIPTION
Closes #23.

Also: 

- Adds support for specifying headers on API requests if needed.
- Adds debug output for all API requests if the `--debug` flag or `DEBUG` environment variable is set. 