### PR TITLE
Do logging through hashicorp/logutils

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"os/user"
@@ -76,7 +77,7 @@ func LogInvoke(ctx *kong.Context) {
 	}
 	err := Submit(e)
 	if err != nil {
-		fmt.Println("Warning: Unable to submit analytics – continuing anyway.")
+		log.Println("[WARN] Unable to submit analytics – continuing anyway.")
 	}
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -64,12 +65,10 @@ func request(method string, u url.URL, body io.Reader, headers ...http.Header) (
 	}
 	req.SetBasicAuth(user, token)
 
-	if Debug {
-		fmt.Println("[DEBUG] Request URL:", req.URL)
-		for k, vs := range req.Header {
-			for _, v := range vs {
-				fmt.Printf("[DEBUG] Header: %s: %v\n", k, v)
-			}
+	log.Println("[DEBUG] Request URL:", req.URL)
+	for k, vs := range req.Header {
+		for _, v := range vs {
+			log.Printf("[DEBUG] Header: %s: %v\n", k, v)
 		}
 	}
 	resp, err = client.Do(req)

--- a/api/applications.go
+++ b/api/applications.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 )
 
@@ -179,9 +180,7 @@ func ApplicationEnvironmentModuleUpdate(accountID int, applicationID int, env st
 	if err != nil {
 		return fmt.Errorf("failed to encode json payload: %v", err)
 	}
-	if Debug {
-		fmt.Printf("[DEBUG] JSON payload: %s\n", b)
-	}
+	log.Printf("[DEBUG] JSON payload: %s\n", b)
 	headers := map[string][]string{"filepath": []string{filePath}}
 	resp, err := request(http.MethodPatch, u, bytes.NewBuffer(b), headers)
 	if err != nil {

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -77,12 +78,9 @@ func (c *DeployCmd) Run() (err error) {
 		s.Stop()
 		return fmt.Errorf("unable to build file list: %s", err)
 	}
-	if c.Debug {
-		fmt.Println()
-		fmt.Println("[debug] Archiving files:")
-		for _, file := range files {
-			fmt.Println("[debug]", file)
-		}
+	log.Println("[DEBUG] Archiving files:")
+	for _, file := range files {
+		log.Println("[DEBUG]", file)
 	}
 
 	tempFile, err := ioutil.TempFile("", "sectionctl-deploy.*.tar.gz")
@@ -105,9 +103,7 @@ func (c *DeployCmd) Run() (err error) {
 	}
 	s.Stop()
 
-	if c.Debug {
-		fmt.Println("[debug] Temporary tarball path:", tempFile.Name())
-	}
+	log.Println("[DEBUG] Temporary tarball path:", tempFile.Name())
 	stat, err := tempFile.Stat()
 	if err != nil {
 		return fmt.Errorf("%s: could not stat, got error: %s", tempFile.Name(), err)
@@ -132,14 +128,10 @@ func (c *DeployCmd) Run() (err error) {
 	}
 	req.SetBasicAuth(username, password)
 
-	if c.Debug {
-		fmt.Println("[debug] Request URL:", req.URL)
-	}
+	log.Println("[DEBUG] Request URL:", req.URL)
 
 	artifactSizeMB := stat.Size() / 1024 / 1024
-	if c.Debug {
-		fmt.Printf("[debug] Upload artifact is %dMB (%d bytes) large", artifactSizeMB, stat.Size())
-	}
+	log.Printf("[DEBUG] Upload artifact is %dMB (%d bytes) large", artifactSizeMB, stat.Size())
 	s.Suffix = fmt.Sprintf(" Uploading app (%dMB)...", artifactSizeMB)
 	s.Start()
 	client := &http.Client{

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -90,7 +90,7 @@ func (c *DeployCmd) Run() (err error) {
 	}
 	if c.SkipDelete {
 		s.Stop()
-		fmt.Println("[INFO] Temporary upload tarball location:", tempFile.Name())
+		log.Println("[INFO] Temporary upload tarball location:", tempFile.Name())
 		s.Start()
 	} else {
 		defer os.Remove(tempFile.Name())

--- a/commands/login.go
+++ b/commands/login.go
@@ -32,7 +32,7 @@ func (c *LoginCmd) Run() (err error) {
 		if strings.Contains(err.Error(), "401") {
 			return fmt.Errorf("invalid credentials. Please try again")
 		}
-		return fmt.Errorf("\ncould not fetch current user: %s", err)
+		return fmt.Errorf("could not fetch current user: %s", err)
 	}
 	fmt.Println("success!")
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/briandowns/spinner v1.11.1
 	github.com/creack/pty v1.1.11
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/jdxcode/netrc v0.0.0-20190329161231-b36f1c51d91d
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/briandowns/spinner v1.11.1
 	github.com/creack/pty v1.1.11
 	github.com/denisbrodbeck/machineid v1.0.1
-	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/logutils v1.0.0
 	github.com/jdxcode/netrc v0.0.0-20190329161231-b36f1c51d91d
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
+github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/jdxcode/netrc v0.0.0-20190329161231-b36f1c51d91d h1:Io4Ts9W/92wkP9VKQTbGpY5VczamXILBrpz490a1/vw=
 github.com/jdxcode/netrc v0.0.0-20190329161231-b36f1c51d91d/go.mod h1:PSWm5RA4GUQ+cyCXiBIIUjlDWdJci5cU3GVKwaQRmW8=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -27,7 +27,6 @@ type CLI struct {
 	SectionToken       string                       `env:"SECTION_TOKEN" help:"Secret token for API auth"`
 	SectionAPIPrefix   *url.URL                     `default:"https://aperture.section.io" env:"SECTION_API_PREFIX"`
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"install shell completions"`
-	logFilter          *logutils.LevelFilter
 }
 
 func bootstrap(c CLI) {

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 
 	"github.com/alecthomas/kong"
+	"github.com/hashicorp/logutils"
 	"github.com/posener/complete"
 	"github.com/section/sectionctl/analytics"
 	"github.com/section/sectionctl/api"
@@ -26,6 +28,7 @@ type CLI struct {
 	SectionToken       string                       `env:"SECTION_TOKEN" help:"Secret token for API auth"`
 	SectionAPIPrefix   *url.URL                     `default:"https://aperture.section.io" env:"SECTION_API_PREFIX"`
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"install shell completions"`
+	logFilter          *logutils.LevelFilter
 }
 
 func bootstrap(c CLI) {
@@ -33,6 +36,16 @@ func bootstrap(c CLI) {
 	api.PrefixURI = c.SectionAPIPrefix
 	api.Username = c.SectionUsername
 	api.Token = c.SectionToken
+
+	filter := &logutils.LevelFilter{
+		Levels:   []logutils.LogLevel{"DEBUG", "WARN", "ERROR"},
+		MinLevel: logutils.LogLevel("WARN"),
+		Writer:   os.Stderr,
+	}
+	if c.Debug {
+		filter.MinLevel = logutils.LogLevel("DEBUG")
+	}
+	log.SetOutput(filter)
 }
 
 func main() {

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -38,8 +38,8 @@ func bootstrap(c CLI) {
 	api.Token = c.SectionToken
 
 	filter := &logutils.LevelFilter{
-		Levels:   []logutils.LogLevel{"DEBUG", "WARN", "ERROR"},
-		MinLevel: logutils.LogLevel("WARN"),
+		Levels:   []logutils.LogLevel{"DEBUG", "INFO", "WARN", "ERROR"},
+		MinLevel: logutils.LogLevel("INFO"),
 		Writer:   os.Stderr,
 	}
 	if c.Debug {

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/url"
 	"os"
@@ -65,7 +64,7 @@ func main() {
 	analytics.LogInvoke(ctx)
 	err := ctx.Run()
 	if err != nil {
-		fmt.Printf("\nError: %s\n", err)
+		log.Printf("[ERROR] %s\n", err)
 		os.Exit(2)
 	}
 }


### PR DESCRIPTION
Closes #22.

Puts all debug, warning, and error level output through the `log` package. 

Set the log level based on the `--debug` flag at the beginning of execution. 

Normal user feedback is still being output by `fmt.Print*`. I'm not sure if we should change all of them to log at the `INFO` level. On the one hand, it would be consistent. On the other, there will be a _lot_ of boilerplate output that will likely be confusing to users. 

WDYT @jstangroome?