### PR TITLE
Separate build and release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\//}
 
     - name: Build
-      run: make build
+      run: make build-release
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 bin/
 build/
 dist/
+sectionctl

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,11 @@ gostaticcheck:
 goerrcheck:
 	errcheck -exclude .lint/errcheck-excludes -blank -ignoretests ./...
 
-export GOARCH := amd64
 build: clean
+	go build -ldflags "-X 'github.com/section/sectionctl/version.Version=dev'" -o sectionctl sectionctl.go
+
+export GOARCH := amd64
+build-release: clean
 	@if [ -z "$(VERSION)" ]; then echo "Missing VERSION"; exit 1 ; fi
 	@if [ -z "$(GOOS)" ]; then echo "Missing GOOS"; exit 1 ; fi
 	@if [ -z "$(GOARCH)" ]; then echo "Missing GOARCH"; exit 1 ; fi

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-release: clean
 	tar --create --gzip --verbose --file dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH).tar.gz --directory dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH) .
 
 clean:
-	rm -rf build
+	rm -rf dist
 
 check_version:
 	@if [ -z "$(VERSION)" ]; then echo "Missing VERSION"; exit 1 ; fi

--- a/README.md
+++ b/README.md
@@ -48,7 +48,17 @@ cd sectionctl
 make test
 ```
 
-To build a binary in `bin/`
+To run a development version of `sectionctl`:
+
+```
+go run sectionctl.go
+```
+
+Add whatever flags and arguments you need at the end of above command.
+
+### Building
+
+To build a binary at `./sectionctl`:
 
 ```
 make build


### PR DESCRIPTION
Split build and release automation:

- Add a new target ('build-release') for building a releasable artifact to be used only for building releasable binaries.
- Make the `build` target work with no configuration, for a smoother local dev experience.
- When building a dev binary, set the version as `dev`, to make it clear the built artifact isn't a released one.
- Document how to do local development