### PR TITLE
Make sure short flags are unique

### DIFF
--- a/commands/ps.go
+++ b/commands/ps.go
@@ -9,7 +9,7 @@ import (
 // PsCmd checks an application's status on Section's delivery platform
 type PsCmd struct {
 	AccountID int `required short:"a"`
-	AppID     int `required short:"a"`
+	AppID     int `required short:"i"`
 }
 
 func getStatus(as api.AppStatus) string {


### PR DESCRIPTION
`sectionctl ps` accepts two flags: `--account-id`, and `--app-id`. 

Previously, both of these flags use the `-a` short flag. 

This PR makes the short flags consistent with the rest of the subcommands:

| long flag | short flag |
| --------  | --------- |
| `--account-id` | `-a` |
| `--app-id` | `-i` |