### PR TITLE
Make analytics async

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -77,7 +77,7 @@ func AsyncLogInvoke(ctx *kong.Context) {
 
 	exe, err := os.Executable()
 	if err != nil {
-		log.Printf("[WARN] Unable to submit analytics: %s", err)
+		log.Printf("[WARN] Unable to get executable to submit analytics: %s", err)
 		return
 	}
 
@@ -95,6 +95,10 @@ func AsyncLogInvoke(ctx *kong.Context) {
 	}
 
 	j, err := json.Marshal(e)
+	if err != nil {
+		log.Printf("[WARN] Unable to build JSON to submit analytics: %s", err)
+		return
+	}
 
 	cmd := exec.Command(exe, "analytics", "--event", string(j))
 	err = cmd.Start()
@@ -116,7 +120,7 @@ func AsyncLogError(ctx *kong.Context, uerr error) {
 
 	exe, err := os.Executable()
 	if err != nil {
-		log.Printf("[WARN] Unable to submit analytics: %s", err)
+		log.Printf("[WARN] Unable to get executable to submit analytics: %s", err)
 		return
 	}
 
@@ -131,6 +135,10 @@ func AsyncLogError(ctx *kong.Context, uerr error) {
 	}
 
 	j, err := json.Marshal(e)
+	if err != nil {
+		log.Printf("[WARN] Unable to build JSON to submit analytics: %s", err)
+		return
+	}
 
 	cmd := exec.Command(exe, "analytics", "--event", string(j))
 	err = cmd.Start()

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -64,8 +64,8 @@ func identity() (id string) {
 	return "unknown"
 }
 
-// LogInvoke logs an invocation of the cli
-func LogInvoke(ctx *kong.Context) {
+// AsyncLogInvoke logs an invocation of the cli
+func AsyncLogInvoke(ctx *kong.Context) {
 	if ctx.Command() == "analytics" {
 		return
 	}

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -21,9 +21,8 @@ func TestAnalyticsSubmitPostsToHeap(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
 
-		body, err := ioutil.ReadAll(r.Body)
+		_, err := ioutil.ReadAll(r.Body)
 		assert.NoError(err)
-		t.Logf("%s", body)
 	}))
 	HeapBaseURI = ts.URL
 

--- a/commands/analytics.go
+++ b/commands/analytics.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/section/sectionctl/analytics"
+)
+
+// AnalyticsCmd handles recording analytics events
+type AnalyticsCmd struct {
+	Event string `required`
+}
+
+// Run executes the command
+func (c *AnalyticsCmd) Run() (err error) {
+	var e analytics.Event
+	err = json.Unmarshal([]byte(c.Event), &e)
+	if err != nil {
+		return fmt.Errorf("unable to parse JSON event: %w", err)
+	}
+	err = analytics.Submit(e)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/section/sectionctl
 
 go 1.13
 
+replace github.com/willabides/kongplete => github.com/auxesis/kongplete v0.1.1-0.20201210052604-333732bbc149
+
 require (
 	github.com/alecthomas/kong v0.2.12
 	github.com/briandowns/spinner v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/alecthomas/kong v0.2.2/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
 github.com/alecthomas/kong v0.2.12 h1:X3kkCOXGUNzLmiu+nQtoxWqj4U2a39MpSJR3QdQXOwI=
 github.com/alecthomas/kong v0.2.12/go.mod h1:kQOmtJgV+Lb4aj+I2LEn40cbtawdWJ9Y8QLq+lElKxE=
+github.com/auxesis/kongplete v0.1.1-0.20201210052604-333732bbc149 h1:lKoNKmlcttwd30UjFzGlaI0CL/CL5qpaP35omkDpf7c=
+github.com/auxesis/kongplete v0.1.1-0.20201210052604-333732bbc149/go.mod h1:kFVw+PkQsqkV7O4tfIBo6iJ9qY94PJC8sPfMgFG5AdM=
 github.com/briandowns/spinner v1.12.0 h1:72O0PzqGJb6G3KgrcIOtL/JAGGZ5ptOMCn9cUHmqsmw=
 github.com/briandowns/spinner v1.12.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -65,6 +65,7 @@ func main() {
 	err := ctx.Run()
 	if err != nil {
 		log.Printf("[ERROR] %s\n", err)
+		analytics.AsyncLogError(ctx, err)
 		os.Exit(2)
 	}
 }

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -24,6 +24,7 @@ type CLI struct {
 	Version            commands.VersionCmd          `cmd help:"Print sectionctl version"`
 	WhoAmI             commands.WhoAmICmd           `cmd name:"whoami" help:"Show information about the currently authenticated user"`
 	Ps                 commands.PsCmd               `cmd help:"Show status of running applications"`
+	Analytics          commands.AnalyticsCmd        `cmd hidden`
 	Debug              bool                         `env:"DEBUG" help:"Enable debug output"`
 	SectionToken       string                       `env:"SECTION_TOKEN" help:"Secret token for API auth"`
 	SectionAPIPrefix   *url.URL                     `default:"https://aperture.section.io" env:"SECTION_API_PREFIX"`

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -61,7 +61,7 @@ func main() {
 		kong.ConfigureHelp(kong.HelpOptions{Tree: true}),
 	)
 	bootstrap(cli)
-	analytics.LogInvoke(ctx)
+	analytics.AsyncLogInvoke(ctx)
 	err := ctx.Run()
 	if err != nil {
 		log.Printf("[ERROR] %s\n", err)


### PR DESCRIPTION
Pulls analytics off the critical execution path, so `sectionctl` runs faster for users. 

When users have given consent, and analytics events need to be recorded, spawn a separate process to send the event.

The only visible change to users should be that `sectionctl` now runs a lot faster (because a blocking HTTP POST to Heap now happens async in the background).