### PR TITLE
Inject version at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ export GOARCH := amd64
 build-release: clean check_version
 	@if [ -z "$(GOOS)" ]; then echo "Missing GOOS"; exit 1 ; fi
 	@if [ -z "$(GOARCH)" ]; then echo "Missing GOARCH"; exit 1 ; fi
-	go build -ldflags "-X 'github.com/section/sectionctl/analytics.HeapAppID=$(HEAPAPPID)'" -o bin/sectionctl sectionctl.go
+	go build -ldflags "-X 'github.com/section/sectionctl/analytics.HeapAppID=$(HEAPAPPID)' -X 'github.com/section/sectionctl/version.Version=$(shell echo $(VERSION) | cut -c 2-)'" -o bin/sectionctl sectionctl.go
 	mkdir -p dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH)/
 	cp README.md LICENSE bin/sectionctl dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH)/
 	tar --create --gzip --verbose --file dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH).tar.gz --directory dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH) .

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build-release: clean check_version
 	tar --create --gzip --verbose --file dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH).tar.gz --directory dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH) .
 
 clean:
-	rm -rf dist
+	rm -rf dist bin
 
 check_version:
 	@if [ -z "$(VERSION)" ]; then echo "Missing VERSION"; exit 1 ; fi

--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ export GOARCH := amd64
 build-release: clean check_version
 	@if [ -z "$(GOOS)" ]; then echo "Missing GOOS"; exit 1 ; fi
 	@if [ -z "$(GOARCH)" ]; then echo "Missing GOARCH"; exit 1 ; fi
-	go build -ldflags "-X 'github.com/section/sectionctl/analytics.HeapAppID=$(HEAPAPPID)' -X 'github.com/section/sectionctl/version.Version=$(shell echo $(VERSION) | cut -c 2-)'" -o bin/sectionctl sectionctl.go
+	go build -ldflags "-X 'github.com/section/sectionctl/analytics.HeapAppID=$(HEAPAPPID)' -X 'github.com/section/sectionctl/version.Version=$(shell echo $(VERSION) | cut -c 2-)'" sectionctl.go
 	mkdir -p dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH)/
-	cp README.md LICENSE bin/sectionctl dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH)/
+	cp README.md LICENSE sectionctl dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH)/
 	tar --create --gzip --verbose --file dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH).tar.gz --directory dist/sectionctl-$(VERSION)-$(GOOS)-$(GOARCH) .
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,7 @@ build: clean
 	go build sectionctl.go
 
 export GOARCH := amd64
-build-release: clean
-	@if [ -z "$(VERSION)" ]; then echo "Missing VERSION"; exit 1 ; fi
+build-release: clean check_version
 	@if [ -z "$(GOOS)" ]; then echo "Missing GOOS"; exit 1 ; fi
 	@if [ -z "$(GOARCH)" ]; then echo "Missing GOARCH"; exit 1 ; fi
 	go build -ldflags "-X 'github.com/section/sectionctl/analytics.HeapAppID=$(HEAPAPPID)'" -o bin/sectionctl sectionctl.go

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ goerrcheck:
 	errcheck -exclude .lint/errcheck-excludes -blank -ignoretests ./...
 
 build: clean
-	go build -ldflags "-X 'github.com/section/sectionctl/version.Version=dev'" -o sectionctl sectionctl.go
+	go build sectionctl.go
 
 export GOARCH := amd64
 build-release: clean

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ release: check_version
 	@if [ "$(shell git branch --show-current)" != "master" ]; then echo "Must be on the 'master' branch"; exit 1 ; fi
 	@git update-index --refresh
 	@git diff-index --quiet HEAD --
-	@if [ "$(shell grep -c $(shell echo $(VERSION) | cut -c 2-) version/version.go)" != "1" ]; then echo "Error: version mismatch with version/version.go"; exit 1 ; fi
 	git tag -f -a $(VERSION) -m ''
 	git push origin master
 	git push origin refs/tags/$(VERSION)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ make build
 
 ## Releasing
 
-1. Increment the version number in `version/version.go` and commit.
-1. Run `make release` and specify VERSION string prefaced with a `v`, like `v1.0.1`.
+Run `make release` and specify VERSION string prefaced with a `v`, like `v1.0.1`.
 
 This triggers [a GitHub Actions workflow](https://github.com/section/sectionctl/actions?query=workflow%3A%22Build+and+release+sectionctl+binaries%22) that does cross platform builds, and publishes [a draft release](https://github.com/section/sectionctl/releases).

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version is the version number of sectionctl
-	Version = "1.3.0"
+	Version = "dev"
 )


### PR DESCRIPTION
- Make the default version `dev` (visible when you do a `go run sectionctl.go version`, or are running a locally built binary)
- Only inject a version when cutting a release (after tagging and pushing with `make release`)