### PR TITLE
Allow variable Node.js directory paths, default to 'nodejs'

### DIFF
--- a/api/applications.go
+++ b/api/applications.go
@@ -228,7 +228,7 @@ func getEnvironmentID(accountID int, applicationID int, environmentName string) 
 }
 
 // ApplicationStatus returns a module's current status on Section's delivery platform
-func ApplicationStatus(accountID int, applicationID int) (as []AppStatus, err error) {
+func ApplicationStatus(accountID int, applicationID int, moduleName string) (as []AppStatus, err error) {
 	u := BaseURL()
 	u.Path = "/new/authorized/graphql_api/query"
 
@@ -246,7 +246,7 @@ func ApplicationStatus(accountID int, applicationID int) (as []AppStatus, err er
 	}
 
 	requestData.Variables = map[string]interface{}{
-		"moduleName":    "nodejs",
+		"moduleName":    moduleName,
 		"environmentID": environmentID,
 	}
 	requestData.Query = "query DeploymentStatus($moduleName: String!, $environmentID: Int!){deploymentStatus(moduleName:$moduleName, environmentID:$environmentID){inService state instanceName payloadID}}"

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -35,6 +35,7 @@ type DeployCmd struct {
 	ServerURL   *url.URL      `default:"https://aperture.section.io/new/code_upload/v1/upload" help:"URL to upload application to"`
 	Timeout     time.Duration `default:"300s" help:"Timeout of individual HTTP requests."`
 	SkipDelete  bool          `help:"Skip delete of temporary tarball created to upload app."`
+	AppPath     string        `default:"nodejs" help:"Path of NodeJS application in environment repository."`
 }
 
 // UploadResponse represents the response from a request to the upload service.
@@ -160,7 +161,7 @@ func (c *DeployCmd) Run() (err error) {
 			},
 		},
 	}
-	err = api.ApplicationEnvironmentModuleUpdate(c.AccountID, c.AppID, c.Environment, "nodejs/.section-external-source.json", ups)
+	err = api.ApplicationEnvironmentModuleUpdate(c.AccountID, c.AppID, c.Environment, c.AppPath + "/.section-external-source.json", ups)
 	s.Stop()
 	if err != nil {
 		return fmt.Errorf("failed to trigger app update: %v", err)

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -272,6 +272,7 @@ func TestCommandsDeployUploadsTarball(t *testing.T) {
 		AccountID:   100,
 		AppID:       200,
 		Environment: "dev",
+		AppPath:     "nodejs",
 	}
 	err = c.Run()
 

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -9,8 +9,9 @@ import (
 
 // PsCmd checks an application's status on Section's delivery platform
 type PsCmd struct {
-	AccountID int `required short:"a" help:"ID of account to query"`
-	AppID     int `required short:"i" help:"ID of app to query"`
+	AccountID int    `required short:"a" help:"ID of account to query"`
+	AppID     int    `required short:"i" help:"ID of app to query"`
+	AppPath   string `default:"nodejs" help:"Path of NodeJS application in environment repository."`
 }
 
 func getStatus(as api.AppStatus) string {
@@ -33,7 +34,7 @@ func (c *PsCmd) Run() (err error) {
 	s := NewSpinner("Getting status of app")
 	s.Start()
 
-	appStatus, err := api.ApplicationStatus(c.AccountID, c.AppID)
+	appStatus, err := api.ApplicationStatus(c.AccountID, c.AppID, c.AppPath)
 	s.Stop()
 	if err != nil {
 		return err


### PR DESCRIPTION
Allow `sectionctl deploy` and `sectionctl ps` to specify the folder path of NodeJS module in Section repo. 
This is to allow users to use something other than the default path of `nodejs`