### PR TITLE
Raise auth specific errors

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -29,7 +29,14 @@ func Accounts() (as []Account, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return as, prettyTxIDError(resp)
+		switch resp.StatusCode {
+		case 401:
+			return as, ErrStatusUnauthorized
+		case 403:
+			return as, ErrStatusForbidden
+		default:
+			return as, prettyTxIDError(resp)
+		}
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -18,6 +19,13 @@ var (
 	timeout   = 20 * time.Second
 	// Token is the token for authenticating to the Section API
 	Token string
+
+	// ErrAuthDenied represents all authentication and authorization errors
+	ErrAuthDenied = errors.New("denied")
+	// ErrStatusUnauthorized (401) indicates that the request has not been applied because it lacks valid authentication credentials for the target resource.
+	ErrStatusUnauthorized = fmt.Errorf("check your token? API request is unauthorized: %w", ErrAuthDenied)
+	// ErrStatusForbidden (403) indicates that the server understood the request but refuses to authorize it.
+	ErrStatusForbidden = fmt.Errorf("check your token? API request is forbidden: %w", ErrAuthDenied)
 )
 
 // BaseURL returns a URL for building requests on

--- a/api/api.go
+++ b/api/api.go
@@ -18,8 +18,6 @@ var (
 	timeout   = 20 * time.Second
 	// Token is the token for authenticating to the Section API
 	Token string
-	// Debug toggles whether extra information is emitted from requests/responses
-	Debug bool
 )
 
 // BaseURL returns a URL for building requests on

--- a/api/applications.go
+++ b/api/applications.go
@@ -62,7 +62,14 @@ func Application(accountID int, applicationID int) (a App, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return a, prettyTxIDError(resp)
+		switch resp.StatusCode {
+		case 401:
+			return a, ErrStatusUnauthorized
+		case 403:
+			return a, ErrStatusForbidden
+		default:
+			return a, prettyTxIDError(resp)
+		}
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -104,7 +111,14 @@ func ApplicationEnvironments(accountID int, applicationID int) (es []Environment
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return es, prettyTxIDError(resp)
+		switch resp.StatusCode {
+		case 401:
+			return es, ErrStatusUnauthorized
+		case 403:
+			return es, ErrStatusForbidden
+		default:
+			return es, prettyTxIDError(resp)
+		}
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -131,7 +145,14 @@ func ApplicationEnvironmentStack(accountID int, applicationID int, environmentNa
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return s, prettyTxIDError(resp)
+		switch resp.StatusCode {
+		case 401:
+			return s, ErrStatusUnauthorized
+		case 403:
+			return s, ErrStatusForbidden
+		default:
+			return s, prettyTxIDError(resp)
+		}
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -158,7 +179,14 @@ func Applications(accountID int) (as []App, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return as, fmt.Errorf("request failed with status %s", resp.Status)
+		switch resp.StatusCode {
+		case 401:
+			return as, ErrStatusUnauthorized
+		case 403:
+			return as, ErrStatusForbidden
+		default:
+			return as, prettyTxIDError(resp)
+		}
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -259,7 +287,14 @@ func ApplicationStatus(accountID int, applicationID int, moduleName string) (as 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return as, prettyTxIDError(resp)
+		switch resp.StatusCode {
+		case 401:
+			return as, ErrStatusUnauthorized
+		case 403:
+			return as, ErrStatusForbidden
+		default:
+			return as, prettyTxIDError(resp)
+		}
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/domains.go
+++ b/api/domains.go
@@ -37,7 +37,14 @@ func DomainsRenewCert(accountID int, hostname string) (r RenewCertResponse, err 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return r, prettyTxIDError(resp)
+		switch resp.StatusCode {
+		case 401:
+			return r, ErrStatusUnauthorized
+		case 403:
+			return r, ErrStatusForbidden
+		default:
+			return r, prettyTxIDError(resp)
+		}
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/user.go
+++ b/api/user.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 )
@@ -32,11 +31,14 @@ func CurrentUser() (u User, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return u, err
+		switch resp.StatusCode {
+		case 401:
+			return u, ErrStatusUnauthorized
+		case 403:
+			return u, ErrStatusForbidden
+		default:
+			return u, prettyTxIDError(resp)
 		}
-		return u, fmt.Errorf("request failed with status \"%s\" and message \"%s\"", resp.Status, body)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -56,5 +56,5 @@ func TestAPIUserHandlesErrors(t *testing.T) {
 	assert.Error(err)
 	assert.Equal(u, User{})
 	assert.Contains(err.Error(), "418")
-	assert.Contains(err.Error(), "short and stout")
+	assert.Contains(err.Error(), "I'm a teapot")
 }

--- a/commands/login.go
+++ b/commands/login.go
@@ -1,10 +1,10 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/section/sectionctl/api"
 	"github.com/section/sectionctl/credentials"
@@ -28,8 +28,8 @@ func (c *LoginCmd) Run() (err error) {
 	_, err = api.CurrentUser()
 	if err != nil {
 		fmt.Println("error!")
-		if strings.Contains(err.Error(), `with status "4`) {
-			return fmt.Errorf("invalid credentials. Please try again")
+		if errors.Is(err, api.ErrAuthDenied) {
+			return err
 		}
 		return fmt.Errorf("could not fetch current user: %w", err)
 	}

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -73,5 +73,5 @@ func TestCommandsLoginValidatesBadCredentials(t *testing.T) {
 	// Test
 	assert.Error(err)
 	assert.True(called)
-	assert.Contains(err.Error(), "invalid credentials")
+	assert.Contains(err.Error(), "unauthorized")
 }

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -34,7 +34,6 @@ type CLI struct {
 }
 
 func bootstrap(c CLI, ctx *kong.Context) {
-	api.Debug = c.Debug
 	api.PrefixURI = c.SectionAPIPrefix
 
 	filter := &logutils.LevelFilter{


### PR DESCRIPTION
Add explicit errors for authentication failures from the API. 

Makes it clearer for API client users if requests are due to auth failures. 