### PR TITLE
Output logs using Golang log libaray instead of tables for better for…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/hashicorp/logutils v1.0.0
 	github.com/kr/pretty v0.1.0 // indirect
+	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/mattn/go-colorable v0.1.2
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/posener/complete v1.2.3
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
+github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=


### PR DESCRIPTION
Changed `sectionctl logs` output from rendering a table to normal line output.
Added colorization that works for windows as well as other OSes.

Powershell 
![image](https://user-images.githubusercontent.com/5294501/103730168-4621ac00-5036-11eb-9725-dc063b362a75.png)

Windows Command Prompt
![image](https://user-images.githubusercontent.com/5294501/103730185-53d73180-5036-11eb-8a58-369bf1c93dc4.png)

Linux 
![image](https://user-images.githubusercontent.com/5294501/103730238-7a956800-5036-11eb-907d-96062c2b029e.png)
