### PR TITLE
Support supplying a token on the command line when logging in

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -18,11 +18,18 @@ type LoginCmd struct {
 
 // Run executes the command
 func (c *LoginCmd) Run() (err error) {
-	t, err := credentials.PromptAndWrite(c.In(), c.Out(), api.PrefixURI.Host)
-	if err != nil {
-		return fmt.Errorf("unable to prompt and write credentials: %w", err)
+	if api.Token != "" {
+		err = credentials.Write(api.PrefixURI.Host, api.Token)
+		if err != nil {
+			return fmt.Errorf("unable to write credential: %w", err)
+		}
+	} else {
+		t, err := credentials.PromptAndWrite(c.In(), c.Out(), api.PrefixURI.Host)
+		if err != nil {
+			return fmt.Errorf("unable to prompt and write credentials: %w", err)
+		}
+		api.Token = t
 	}
-	api.Token = t
 
 	fmt.Print("\nValidating credentials...")
 	_, err = api.CurrentUser()

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -46,7 +46,10 @@ func bootstrap(c CLI, ctx *kong.Context) {
 	}
 	log.SetOutput(filter)
 
-	if ctx.Command() != "login" && ctx.Command() != "logout" {
+	switch {
+	case ctx.Command() == "login":
+		api.Token = c.SectionToken
+	case ctx.Command() != "login" && ctx.Command() != "logout":
 		t := c.SectionToken
 		if t == "" {
 			to, err := credentials.Setup(api.PrefixURI.Host)


### PR DESCRIPTION
Works like this:

```
read -es SECTION_TOKEN
sectionctl login
```

Or less securely (because the secret is stored in shell history): 

``` bash
sectionctl login --section-token s3cr3t:t0k3n
```