### PR TITLE
Don't require user to be logged in to run version

### DIFF
--- a/sectionctl.go
+++ b/sectionctl.go
@@ -48,6 +48,7 @@ func bootstrap(c CLI, ctx *kong.Context) {
 	log.SetOutput(filter)
 
 	switch {
+	case ctx.Command() == "version":
 	case ctx.Command() == "login":
 		api.Token = c.SectionToken
 	case ctx.Command() != "login" && ctx.Command() != "logout":

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -49,6 +49,7 @@ func bootstrap(c CLI, ctx *kong.Context) {
 
 	switch {
 	case ctx.Command() == "version":
+		// bypass auth check for version command
 	case ctx.Command() == "login":
 		api.Token = c.SectionToken
 	case ctx.Command() != "login" && ctx.Command() != "logout":


### PR DESCRIPTION
Before: 

If a user runs `sectionctl version` and they haven't logged in with `sectionctl login`, they will be presented a login prompt before they see the version string.

After: 

The version string is emitted immediately, and auth isn't checked. 