### PR TITLE
Increase and make timeouts configurable

### DIFF
--- a/api/applications.go
+++ b/api/applications.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"time"
 )
 
 // App represents an application deployed on Section
@@ -228,6 +229,7 @@ func ApplicationEnvironmentModuleUpdate(accountID int, applicationID int, env st
 	}
 	log.Printf("[DEBUG] JSON payload: %s\n", b)
 	headers := map[string][]string{"filepath": []string{filePath}}
+	Timeout = 300 * time.Second // five minutes, because server-side validation can take a while
 	resp, err := request(http.MethodPatch, u, bytes.NewBuffer(b), headers)
 	if err != nil {
 		return fmt.Errorf("failed to execute trigger request: %v", err)

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/hashicorp/logutils"
@@ -31,11 +32,13 @@ type CLI struct {
 	Debug              bool                         `env:"DEBUG" help:"Enable debug output"`
 	SectionToken       string                       `env:"SECTION_TOKEN" help:"Secret token for API auth"`
 	SectionAPIPrefix   *url.URL                     `default:"https://aperture.section.io" env:"SECTION_API_PREFIX"`
+	SectionAPITimeout  time.Duration                `default:"30s" env:"SECTION_API_TIMEOUT" help:"Request timeout for the Section API"`
 	InstallCompletions kongplete.InstallCompletions `cmd:"" help:"install shell completions"`
 }
 
 func bootstrap(c CLI, ctx *kong.Context) {
 	api.PrefixURI = c.SectionAPIPrefix
+	api.Timeout = c.SectionAPITimeout
 
 	filter := &logutils.LevelFilter{
 		Levels:   []logutils.LogLevel{"DEBUG", "INFO", "WARN", "ERROR"},


### PR DESCRIPTION
Increase the timeout on patch requests to update module configuration to 5 minutes, as server side validation of changes can take a while. 

Make request timeouts globally configurable with `--section-api-timeout`. 