### PR TITLE
Add ability to skip client side validation

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -159,7 +159,7 @@ func (c *DeployCmd) Run() (err error) {
 			},
 		},
 	}
-	err = api.ApplicationEnvironmentModuleUpdate(c.AccountID, c.AppID, c.Environment, c.AppPath + "/.section-external-source.json", ups)
+	err = api.ApplicationEnvironmentModuleUpdate(c.AccountID, c.AppID, c.Environment, c.AppPath+"/.section-external-source.json", ups)
 	s.Stop()
 	if err != nil {
 		return fmt.Errorf("failed to trigger app update: %v", err)


### PR DESCRIPTION
Some users are uploading workloads that can be served on Section's edge, even though it fails validation. 

This PR provides the ability for users to optionally skip client-side workload validation. 