### PR TITLE
Rename log length to number

### DIFF
--- a/api/applications.go
+++ b/api/applications.go
@@ -329,7 +329,7 @@ func ApplicationStatus(accountID int, applicationID int, moduleName string) (as 
 }
 
 // ApplicationLogs returns a module's logs from Section's delivery platform
-func ApplicationLogs(accountID int, applicationID int, moduleName string, instanceName string, length int) (al []AppLogs, err error) {
+func ApplicationLogs(accountID int, applicationID int, moduleName string, instanceName string, number int) (al []AppLogs, err error) {
 	u := BaseURL()
 	u.Path = "/new/authorized/graphql_api/query"
 
@@ -350,7 +350,7 @@ func ApplicationLogs(accountID int, applicationID int, moduleName string, instan
 		"environmentId": environmentID,
 		"moduleName":    moduleName,
 		"instanceName":  instanceName,
-		"length":        length,
+		"length":        number,
 		// "startTimestamp": startTimestamp,
 		// "endTimestamp": endTimestamp,
 	}

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -19,7 +19,7 @@ type LogsCmd struct {
 	AppID           int    `required short:"i" help:"ID of app to query"`
 	AppPath         string `default:"nodejs" help:"Path of NodeJS application in environment repository."`
 	InstanceName    string `default:"" help:"Specific instance of NodeJS application running on Section platform."`
-	Length          int    `default:100 help:"Number of log lines to fetch."`
+	Number          int    `short:"n" default:100 help:"Number of log lines to fetch."`
 	// StartTimestamp  int    `default:0 help:"Start of log time stamp to fetch."`
 	// EndTimestamp    int    `default:0 help:"End of log time stamp to fetch."`
 }
@@ -29,11 +29,11 @@ func (c *LogsCmd) Run() (err error) {
 	s := NewSpinner("Getting logs from app")
 	s.Start()
 
-	if c.Length > maxNumberLogs {
+	if c.Number > maxNumberLogs {
 		return fmt.Errorf("number of logs queried cannot be over %d", maxNumberLogs)
 	}
 
-	appLogs, err := api.ApplicationLogs(c.AccountID, c.AppID, c.AppPath, c.InstanceName, c.Length)
+	appLogs, err := api.ApplicationLogs(c.AccountID, c.AppID, c.AppPath, c.InstanceName, c.Number)
 	s.Stop()
 	if err != nil {
 		return err


### PR DESCRIPTION
Rename command flag for log "length" to "number" and add shorthand to better align with other command-line tools such a `tail -n`
