### PR TITLE
Stop panics on rate limited requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -76,12 +76,16 @@ func request(method string, u url.URL, body io.Reader, headers ...http.Header) (
 
 // prettyTxIDError creates a support friendly error message with an transaction ID
 func prettyTxIDError(resp *http.Response) error {
-	if resp.StatusCode == http.StatusTooManyRequests {
-		return fmt.Errorf("status 429 - the number of requests have exceeded the maximum allowed for this time period. Please wait a few minutes and try again. Transaction ID: %s", resp.Header["Aperture-Tx-Id"][0])
+	var txIDhelper string
+	if len(resp.Header["Aperture-Tx-Id"]) > 0 {
+		txIDhelper = fmt.Sprintf(" and Section Transaction ID %s", resp.Header["Aperture-Tx-Id"][0])
 	}
 
-	if len(resp.Header["Aperture-Tx-Id"]) > 0 {
-		return fmt.Errorf("request failed with status %s and transaction ID %s", resp.Status, resp.Header["Aperture-Tx-Id"][0])
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return fmt.Errorf("status 429%s: the number of requests have exceeded the maximum allowed for this time period. Please wait a few minutes and try again", txIDhelper)
+	default:
+		return fmt.Errorf("request failed with status %s%s", resp.Status, txIDhelper)
+
 	}
-	return fmt.Errorf("request failed with status %s", resp.Status)
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -53,7 +53,7 @@ func TestPrettyTxIDErrorPrintsApertureTxID(t *testing.T) {
 
 	// Test
 	assert.Error(err)
-	assert.Regexp("transaction ID", err)
+	assert.Regexp("Section Transaction ID", err)
 	assert.Regexp(resp.Header["Aperture-Tx-Id"][0], err)
 }
 
@@ -67,7 +67,24 @@ func TestPrettyTxIDErrorHandlesNoApertureTxIDHeader(t *testing.T) {
 
 	// Test
 	assert.Error(err)
-	assert.NotRegexp("transaction ID", err)
+	assert.NotRegexp("Section Transaction ID", err)
+}
+
+func TestPrettyTxIDErrorHandlesRateLimiting(t *testing.T) {
+	assert := assert.New(t)
+
+	// Invoke
+	resp := http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     map[string][]string{"Aperture-Tx-Id": []string{"12345"}},
+	}
+	assert.NotPanics(func() { prettyTxIDError(&resp) })
+	err := prettyTxIDError(&resp)
+
+	// Test
+	assert.Error(err)
+	assert.Regexp(resp.Header["Aperture-Tx-Id"][0], err)
+	assert.Regexp("Please wait a few minutes", err)
 }
 
 func TestAPIClientUsesCredentialsIfSpecified(t *testing.T) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -48,7 +48,10 @@ func TestPrettyTxIDErrorPrintsApertureTxID(t *testing.T) {
 	assert := assert.New(t)
 
 	// Invoke
-	resp := http.Response{Status: "500 Internal Server Error", Header: map[string][]string{"Aperture-Tx-Id": []string{"12345"}}}
+	resp := http.Response{
+		Status: "500 Internal Server Error",
+		Header: map[string][]string{"Aperture-Tx-Id": []string{"12345"}},
+	}
 	err := prettyTxIDError(&resp)
 
 	// Test


### PR DESCRIPTION
Stop an accidental panic if there is no `Aperture-Tx-Id` header set on rate limited requests.