### PR TITLE
Make request timeouts explicit with context

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -22,7 +23,10 @@ func Accounts() (as []Account, err error) {
 	u := BaseURL()
 	u.Path += "/account"
 
-	resp, err := request(http.MethodGet, u, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+
+	resp, err := request(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return as, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -41,7 +41,7 @@ func BaseURL() (u url.URL) {
 //
 // You can pass 0 or more headers, and keys in the later headers will override earlier passed headers.
 func request(ctx context.Context, method string, u url.URL, body io.Reader, headers ...http.Header) (resp *http.Response, err error) {
-	var client http.Client{}
+	var client http.Client
 
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -39,12 +40,10 @@ func BaseURL() (u url.URL) {
 // request does the heavy lifting of making requests to the Section API.
 //
 // You can pass 0 or more headers, and keys in the later headers will override earlier passed headers.
-func request(method string, u url.URL, body io.Reader, headers ...http.Header) (resp *http.Response, err error) {
-	client := &http.Client{
-		Timeout: Timeout,
-	}
+func request(ctx context.Context, method string, u url.URL, body io.Reader, headers ...http.Header) (resp *http.Response, err error) {
+	client := http.Client{}
 
-	req, err := http.NewRequest(method, u.String(), body)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {
 		return resp, err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -28,6 +28,9 @@ var (
 	ErrStatusUnauthorized = fmt.Errorf("check your token? API request is unauthorized: %w", ErrAuthDenied)
 	// ErrStatusForbidden (403) indicates that the server understood the request but refuses to authorize it.
 	ErrStatusForbidden = fmt.Errorf("check your token? API request is forbidden: %w", ErrAuthDenied)
+
+	// client is the HTTP client used across requests
+	client http.Client
 )
 
 // BaseURL returns a URL for building requests on
@@ -41,8 +44,6 @@ func BaseURL() (u url.URL) {
 //
 // You can pass 0 or more headers, and keys in the later headers will override earlier passed headers.
 func request(ctx context.Context, method string, u url.URL, body io.Reader, headers ...http.Header) (resp *http.Response, err error) {
-	var client http.Client
-
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {
 		return resp, err

--- a/api/api.go
+++ b/api/api.go
@@ -41,7 +41,7 @@ func BaseURL() (u url.URL) {
 //
 // You can pass 0 or more headers, and keys in the later headers will override earlier passed headers.
 func request(ctx context.Context, method string, u url.URL, body io.Reader, headers ...http.Header) (resp *http.Response, err error) {
-	client := http.Client{}
+	var client http.Client{}
 
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zalando/go-keyring"
@@ -36,8 +38,11 @@ func TestAPIClientSetsUserAgent(t *testing.T) {
 	u, err := url.Parse(ts.URL)
 	assert.NoError(err)
 
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+
 	// Invoke
-	_, err = request(http.MethodGet, *u, nil)
+	_, err = request(ctx, http.MethodGet, *u, nil)
 	assert.NoError(err)
 
 	// Test
@@ -109,8 +114,11 @@ func TestAPIClientUsesCredentialsIfSpecified(t *testing.T) {
 	u, err := url.Parse(ts.URL)
 	assert.NoError(err)
 
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+
 	// Invoke
-	resp, err := request(http.MethodGet, *u, nil)
+	resp, err := request(ctx, http.MethodGet, *u, nil)
 	assert.NoError(err)
 
 	// Test
@@ -144,7 +152,10 @@ func TestAPIrequestSendsHeaderArguments(t *testing.T) {
 	assert.NoError(err)
 	Token = "s3cr3t"
 
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+
 	// Invoke
-	_, err = request(http.MethodGet, *u, nil, headers...)
+	_, err = request(ctx, http.MethodGet, *u, nil, headers...)
 	assert.NoError(err)
 }

--- a/api/applications.go
+++ b/api/applications.go
@@ -242,7 +242,7 @@ func ApplicationEnvironmentModuleUpdate(accountID int, applicationID int, env st
 	}
 	log.Printf("[DEBUG] JSON payload: %s\n", b)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute) // because these requests can take a long time to complete on Section's side
 	defer cancel()
 	headers := map[string][]string{"filepath": []string{filePath}}
 

--- a/api/domains.go
+++ b/api/domains.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -30,7 +31,10 @@ func DomainsRenewCert(accountID int, hostname string) (r RenewCertResponse, err 
 	u := BaseURL()
 	u.Path += fmt.Sprintf("/account/%d/domain/%s/renewCertificate", accountID, hostname)
 
-	resp, err := request(http.MethodPost, u, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+
+	resp, err := request(ctx, http.MethodPost, u, nil)
 	if err != nil {
 		return r, err
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -24,7 +25,10 @@ func CurrentUser() (u User, err error) {
 	ur := BaseURL()
 	ur.Path += "/user"
 
-	resp, err := request(http.MethodGet, ur, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), Timeout)
+	defer cancel()
+
+	resp, err := request(ctx, http.MethodGet, ur, nil)
 	if err != nil {
 		return u, err
 	}


### PR DESCRIPTION
As promised in #73, this PR makes timeouts explicit by setting them on a `context.Context`.