### PR TITLE
Fix ignore directories and filemode of node binaries on windows

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -279,7 +279,6 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer, prefix string) e
 		match := strings.Contains(baseFilePath,"node_modules\\.bin")
 		if match {
 			header.Mode = 511 // This is the value that it spat out when i ran npm i on linux then checked the int64 value of the stat.Mode() on files in node_modules/.bin/
-			fmt.Printf("added %s\n", baseFilePath);
 		}
 	}
 	err = tarWriter.WriteHeader(header)

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -273,7 +273,14 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer, prefix string) e
 	// must provide real name
 	// (see https://golang.org/src/archive/tar/common.go?#L626)
 	header.Name = filepath.ToSlash(baseFilePath)
-
+  // ensure windows provides filemodes for binaries in node_modules/.bin
+	if runtime.GOOS == "windows" {
+		match := strings.Contains(baseFilePath,"node_modules\\.bin")
+		if match == true {
+			header.Mode = 511 // This is the value that it spat out when i ran npm i on linux then checked the int64 value of the stat.Mode() on files in node_modules/.bin/
+			fmt.Printf("added %s\n", baseFilePath);
+		}
+	}
 	err = tarWriter.WriteHeader(header)
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("Could not write header for file '%s', got error '%s'", baseFilePath, err.Error()))

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -278,7 +278,7 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer, prefix string) e
 	if runtime.GOOS == "windows" {
 		match := strings.Contains(baseFilePath,"node_modules\\.bin")
 		if match {
-			header.Mode = 511 // This is the value that it spat out when i ran npm i on linux then checked the int64 value of the stat.Mode() on files in node_modules/.bin/
+			header.Mode = 0o755
 		}
 	}
 	err = tarWriter.WriteHeader(header)

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -277,7 +277,7 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer, prefix string) e
   // ensure windows provides filemodes for binaries in node_modules/.bin
 	if runtime.GOOS == "windows" {
 		match := strings.Contains(baseFilePath,"node_modules\\.bin")
-		if match == true {
+		if match {
 			header.Mode = 511 // This is the value that it spat out when i ran npm i on linux then checked the int64 value of the stat.Mode() on files in node_modules/.bin/
 			fmt.Printf("added %s\n", baseFilePath);
 		}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -73,7 +73,7 @@ func (c *DeployCmd) Run() (err error) {
 	s := NewSpinner(fmt.Sprintf("Packaging app in: %s", dir))
 	s.Start()
 
-	ignores := []string{".lint/", ".git/"}
+	ignores := []string{".lint", ".git"}
 	files, err := BuildFilelist(dir, ignores)
 	if err != nil {
 		s.Stop()
@@ -194,7 +194,10 @@ func IsValidNodeApp(dir string) (errs []error) {
 
 	return errs
 }
-
+// Split helps differentiate between different directory delimiters. / or \
+func Split(r rune) bool {
+    return r == '\\' || r == '/'
+}
 // BuildFilelist builds a list of files to be tarballed, with optional ignores.
 func BuildFilelist(dir string, ignores []string) (files []string, err error) {
 	var fi os.FileInfo
@@ -207,9 +210,11 @@ func BuildFilelist(dir string, ignores []string) (files []string, err error) {
 
 	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		for _, i := range ignores {
-			if strings.Contains(path, i) {
-				return nil
-
+			location := strings.FieldsFunc(path, Split) // split by subdirectory or filename
+			for _, loc := range location{
+				if strings.Contains(loc, i) {
+					return nil
+				}
 			}
 		}
 		files = append(files, path)


### PR DESCRIPTION
This will fix the way it ignores directories, before it was assuming there was always a forwardslash, but windows uses backslashes.

Also it will ensure anything in the node_modules/.bin/ folder is executable, as windows doesn't set filemode.