### PR TITLE
Make educated guesses about account and app IDs

### DIFF
--- a/commands/apps.go
+++ b/commands/apps.go
@@ -21,7 +21,7 @@ type AppsCmd struct {
 	Info   AppsInfoCmd   `cmd help:"Show detailed app information on Section."`
 	Create AppsCreateCmd `cmd help:"Create new app on Section."`
 	Delete AppsDeleteCmd `cmd help:"Delete an existing app on Section."`
-	Init   AppsInitCmd   `cmd help:"Initilize your project for deployment"`
+	Init   AppsInitCmd   `cmd help:"Initialize your project for deployment"`
 }
 
 // AppsListCmd handles listing apps running on Section

--- a/commands/certs.go
+++ b/commands/certs.go
@@ -13,7 +13,7 @@ type CertsCmd struct {
 
 // CertsRenewCmd handles renewing a certificate
 type CertsRenewCmd struct {
-	AccountID int    `required short:"a"`
+	AccountID int    `required short:"a" help:"Account ID the domain belongs to"`
 	Hostname  string `required`
 }
 

--- a/commands/certs.go
+++ b/commands/certs.go
@@ -13,16 +13,43 @@ type CertsCmd struct {
 
 // CertsRenewCmd handles renewing a certificate
 type CertsRenewCmd struct {
-	AccountID int    `required short:"a" help:"Account ID the domain belongs to"`
-	Hostname  string `required`
+	Hostname string `arg help:"The domain name to renew the cert for"`
 }
 
 // Run executes the command
 func (c *CertsRenewCmd) Run() (err error) {
-	s := NewSpinner(fmt.Sprintf("Renewing cert for %s", c.Hostname))
+	var aid int
+	s := NewSpinner("Looking up accounts")
 	s.Start()
 
-	resp, err := api.DomainsRenewCert(c.AccountID, c.Hostname)
+	as, err := api.Accounts()
+	if err != nil {
+		return fmt.Errorf("unable to look up accounts: %w", err)
+	}
+
+	for _, a := range as {
+		ds, err := api.Domains(a.ID)
+		if err != nil {
+			return fmt.Errorf("unable to look up domains under account ID %d: %w", a.ID, err)
+		}
+		for _, d := range ds {
+			if d.DomainName == c.Hostname {
+				aid = a.ID
+				s.Stop()
+				break
+			}
+		}
+	}
+	s.Stop()
+
+	if aid == 0 {
+		return fmt.Errorf("unable to find the domain '%s' under any of your accounts.\n\nTry running `sectionctl domains` to see all your domains", c.Hostname)
+	}
+
+	s = NewSpinner(fmt.Sprintf("Renewing cert for %s", c.Hostname))
+	s.Start()
+
+	resp, err := api.DomainsRenewCert(aid, c.Hostname)
 	s.Stop()
 	if err != nil {
 		return err

--- a/commands/ps.go
+++ b/commands/ps.go
@@ -1,15 +1,17 @@
 package commands
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/section/sectionctl/api"
 )
 
 // PsCmd checks an application's status on Section's delivery platform
 type PsCmd struct {
-	AccountID int    `required short:"a" help:"ID of account to query"`
-	AppID     int    `required short:"i" help:"ID of app to query"`
+	AccountID int    `short:"a" help:"ID of account to query"`
+	AppID     int    `short:"i" help:"ID of app to query"`
 	AppPath   string `default:"nodejs" help:"Path of NodeJS application in environment repository."`
 }
 
@@ -25,22 +27,69 @@ func getStatus(as api.AppStatus) string {
 
 // Run executes the command
 func (c *PsCmd) Run() (err error) {
-	s := NewSpinner("Getting status of app")
+	var aids []int
+	if c.AccountID == 0 {
+		s := NewSpinner("Looking up accounts")
+		s.Start()
+
+		as, err := api.Accounts()
+		if err != nil {
+			return fmt.Errorf("unable to look up accounts: %w", err)
+		}
+		for _, a := range as {
+			aids = append(aids, a.ID)
+		}
+
+		s.Stop()
+	} else {
+		aids = append(aids, c.AccountID)
+	}
+
+	var targets [][]int
+	for _, id := range aids {
+		if c.AppID == 0 {
+			s := NewSpinner("Looking up applications")
+			s.Start()
+
+			as, err := api.Applications(id)
+			if err != nil {
+				return fmt.Errorf("unable to look up applications: %w", err)
+			}
+			for _, a := range as {
+				targets = append(targets, []int{id, a.ID})
+			}
+
+			s.Stop()
+		} else {
+			targets = append(targets, []int{id, c.AppID})
+		}
+	}
+
+	s := NewSpinner("Getting status of apps")
 	s.Start()
 
-	appStatus, err := api.ApplicationStatus(c.AccountID, c.AppID, c.AppPath)
-	s.Stop()
-	if err != nil {
-		return err
-	}
-
 	table := NewTable(os.Stdout)
-	table.SetHeader([]string{"App instance name", "App Status", "App Payload ID"})
+	table.SetHeader([]string{"Account ID", "App ID", "App instance name", "App Status", "App Payload ID"})
 
-	for _, a := range appStatus {
-		r := []string{a.InstanceName, getStatus(a), a.PayloadID}
-		table.Append(r)
+	for _, t := range targets {
+		appStatus, err := api.ApplicationStatus(t[0], t[1], c.AppPath)
+		s.Stop()
+		if err != nil {
+			return err
+		}
+
+		for _, a := range appStatus {
+			r := []string{
+				strconv.Itoa(t[0]),
+				strconv.Itoa(t[1]),
+				a.InstanceName,
+				getStatus(a),
+				a.PayloadID,
+			}
+			table.Append(r)
+		}
 	}
+
 	table.Render()
 	return nil
 }


### PR DESCRIPTION
Remove the need to specify account and app IDs across the following commands: 

- `sectionctl apps`
- `sectionctl certs renew`
- `sectionctl domains`
- `sectionctl ps`

Where appropriate, make `--account-id` and `--app-id` behave like filters instead of required flags.