### PR TITLE
Add short flag for deploy subcommand

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -31,7 +31,7 @@ type DeployCmd struct {
 	AppID          int           `required short:"i" help:"AppID to deploy application to."`
 	Environment    string        `short:"e" default:"production" help:"Environment to deploy application to."`
 	Debug          bool          `help:"Display extra debugging information about what is happening inside sectionctl."`
-	Directory      string        `default:"." help:"Directory which contains the application to deploy."`
+	Directory      string        `short:"C" default:"." help:"Directory which contains the application to deploy."`
 	ServerURL      *url.URL      `default:"https://aperture.section.io/new/code_upload/v1/upload" help:"URL to upload application to"`
 	Timeout        time.Duration `default:"600s" help:"Timeout of individual HTTP requests."`
 	SkipDelete     bool          `help:"Skip delete of temporary tarball created to upload app."`

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -195,10 +195,12 @@ func IsValidNodeApp(dir string) (errs []error) {
 
 	return errs
 }
+
 // Split helps differentiate between different directory delimiters. / or \
 func Split(r rune) bool {
-    return r == '\\' || r == '/'
+	return r == '\\' || r == '/'
 }
+
 // BuildFilelist builds a list of files to be tarballed, with optional ignores.
 func BuildFilelist(dir string, ignores []string) (files []string, err error) {
 	var fi os.FileInfo
@@ -212,7 +214,7 @@ func BuildFilelist(dir string, ignores []string) (files []string, err error) {
 	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		for _, i := range ignores {
 			location := strings.FieldsFunc(path, Split) // split by subdirectory or filename
-			for _, loc := range location{
+			for _, loc := range location {
 				if strings.Contains(loc, i) {
 					return nil
 				}
@@ -274,9 +276,9 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer, prefix string) e
 	// must provide real name
 	// (see https://golang.org/src/archive/tar/common.go?#L626)
 	header.Name = filepath.ToSlash(baseFilePath)
-  // ensure windows provides filemodes for binaries in node_modules/.bin
+	// ensure windows provides filemodes for binaries in node_modules/.bin
 	if runtime.GOOS == "windows" {
-		match := strings.Contains(baseFilePath,"node_modules\\.bin")
+		match := strings.Contains(baseFilePath, "node_modules\\.bin")
 		if match {
 			header.Mode = 0o755
 		}


### PR DESCRIPTION
Adds the `-C` short flag for the `--directory` flag, to specify where the application to deploy is. 

Mimics the behavior of [GNU tar](https://www.gnu.org/software/tar/manual/tar.html#g_t_002d_002ddirectory).