### PR TITLE
Hide the Section-Token header value, so credentials aren't leaked

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -65,7 +65,7 @@ func request(ctx context.Context, method string, u url.URL, body io.Reader, head
 	for k, vs := range req.Header {
 		for _, v := range vs {
 			if k == "Section-Token" {
-				v = fmt.Sprintf("%s********TOKEN HIDDEN********", v[0:3])
+				v = "********TOKEN HIDDEN********"
 			}
 			log.Printf("[DEBUG] Header: %s: %v\n", k, v)
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -64,6 +64,9 @@ func request(ctx context.Context, method string, u url.URL, body io.Reader, head
 	log.Println("[DEBUG] Request URL:", method, req.URL)
 	for k, vs := range req.Header {
 		for _, v := range vs {
+			if k == "Section-Token" {
+				v = fmt.Sprintf("%s********TOKEN HIDDEN********", v[0:3])
+			}
 			log.Printf("[DEBUG] Header: %s: %v\n", k, v)
 		}
 	}


### PR DESCRIPTION
Important so that credentials aren't accidentally shared with Section staff when submitting support tickets.  

Looks like this: 

```
$ sectionctl apps --debug
2021/02/15 23:36:32 [DEBUG] Request URL: GET https://aperture.section.io/api/v1/account
2021/02/15 23:36:32 [DEBUG] Header: User-Agent: sectionctl (dev; amd64-darwin)
2021/02/15 23:36:32 [DEBUG] Header: Content-Type: application/json
2021/02/15 23:36:32 [DEBUG] Header: Accept: application/json
2021/02/15 23:36:32 [DEBUG] Header: Section-Token: ********TOKEN HIDDEN********
Looking up accounts... done
2021/02/15 23:36:32 [DEBUG] Request URL: GET https://aperture.section.io/api/v1/account/1024/application
2021/02/15 23:36:32 [DEBUG] Header: Content-Type: application/json
Looking up apps... ⠋ 2021/02/15 23:36:32 [DEBUG] Header: Accept: application/json
2021/02/15 23:36:32 [DEBUG] Header: Section-Token: ********TOKEN HIDDEN********
Looking up apps... done
| ACCOUNT ID | APP ID |         APP NAME         |
|------------|--------|--------------------------|
| 1024       | 8192   | www.lindsay.dev          |
| 1024       | 8193   | another.section.dev |
```