### PR TITLE
Write debug logs to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ bin/
 build/
 dist/
 sectionctl
+
+# Debug outputs
+sectionctl-debug-*.log

--- a/commands/version.go
+++ b/commands/version.go
@@ -31,7 +31,7 @@ func (c *VersionCmd) Run() (err error) {
 	errs := make(chan error, 1)
 	go c.checkVersion(reply, errs)
 
-	fmt.Fprintf(c.Out(), "%s (%s-%s)\n", version.Version, runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(c.Out(), "%s\n", c.String())
 
 	if version.Version == "dev" {
 		return err
@@ -105,6 +105,10 @@ func (c *VersionCmd) checkVersion(latest chan string, errs chan error) {
 		return
 	}
 	latest <- latestResp.TagName
+}
+
+func (c VersionCmd) String() string {
+	return fmt.Sprintf("%s (%s-%s)", version.Version, runtime.GOOS, runtime.GOARCH)
 }
 
 // In returns the input to read from

--- a/sectionctl.go
+++ b/sectionctl.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -49,6 +51,18 @@ func bootstrap(c CLI, ctx *kong.Context) {
 	}
 	if c.Debug {
 		filter.MinLevel = logutils.LogLevel("DEBUG")
+		logFilename := fmt.Sprintf("sectionctl-debug-%s.log", time.Now().Format(time.RFC3339))
+		logFile, err := os.OpenFile(logFilename, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Fprintf(logFile, "Version:   %s\n", commands.VersionCmd{}.String())
+		fmt.Fprintf(logFile, "Command:   %s\n", ctx.Args)
+		fmt.Fprintf(logFile, "PrefixURI: %s\n", api.PrefixURI)
+		fmt.Fprintf(logFile, "Timeout:   %s\n", api.Timeout)
+		fmt.Printf("Writing debug log to: %s\n", logFilename)
+		mw := io.MultiWriter(logFile, colorableWriter)
+		filter.Writer = mw
 	}
 	log.SetOutput(filter)
 


### PR DESCRIPTION
When you run `sectionctl` with the `--debug` flag set, also write the debug output to a file. 

This makes it easier for users to report information about their environment when sending support requests. 