### PR TITLE
add environment flag to deploy

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -29,7 +29,7 @@ const MaxFileSize = 1073741824 // 1GB
 type DeployCmd struct {
 	AccountID      int           `required short:"a" help:"AccountID to deploy application to."`
 	AppID          int           `required short:"i" help:"AppID to deploy application to."`
-	Environment    string        `short:"e" default:"Production" help:"Environment to deploy application to."`
+	Environment    string        `short:"e" default:"Production" help:"Environment to deploy application to. (name of git branch ie: Production, staging, development)"`
 	Debug          bool          `help:"Display extra debugging information about what is happening inside sectionctl."`
 	Directory      string        `short:"C" default:"." help:"Directory which contains the application to deploy."`
 	ServerURL      *url.URL      `default:"https://aperture.section.io/new/code_upload/v1/upload" help:"URL to upload application to"`

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -37,6 +37,7 @@ type DeployCmd struct {
 	SkipDelete     bool          `help:"Skip delete of temporary tarball created to upload app."`
 	SkipValidation bool          `help:"Skip validation of the workload before pushing into Section. Use with caution."`
 	AppPath        string        `default:"nodejs" help:"Path of NodeJS application in environment repository."`
+	Branch         string        `short:"b" default:"Production" help:"Name of the environment repository branch to deploy to."`
 }
 
 // UploadResponse represents the response from a request to the upload service.

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -29,7 +29,7 @@ const MaxFileSize = 1073741824 // 1GB
 type DeployCmd struct {
 	AccountID      int           `required short:"a" help:"AccountID to deploy application to."`
 	AppID          int           `required short:"i" help:"AppID to deploy application to."`
-	Environment    string        `short:"e" default:"production" help:"Environment to deploy application to."`
+	Environment    string        `short:"e" default:"Production" help:"Environment to deploy application to."`
 	Debug          bool          `help:"Display extra debugging information about what is happening inside sectionctl."`
 	Directory      string        `short:"C" default:"." help:"Directory which contains the application to deploy."`
 	ServerURL      *url.URL      `default:"https://aperture.section.io/new/code_upload/v1/upload" help:"URL to upload application to"`
@@ -37,7 +37,6 @@ type DeployCmd struct {
 	SkipDelete     bool          `help:"Skip delete of temporary tarball created to upload app."`
 	SkipValidation bool          `help:"Skip validation of the workload before pushing into Section. Use with caution."`
 	AppPath        string        `default:"nodejs" help:"Path of NodeJS application in environment repository."`
-	Branch         string        `short:"b" default:"Production" help:"Name of the environment repository branch to deploy to."`
 }
 
 // UploadResponse represents the response from a request to the upload service.

--- a/commands/gitService.go
+++ b/commands/gitService.go
@@ -12,6 +12,7 @@ import (
 	gitHTTP "github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/section/sectionctl/api"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 // GitService interface provides a way to interact with Git
@@ -43,10 +44,12 @@ func (g *GS) UpdateGitViaGit(c *DeployCmd, response UploadResponse) error {
 		Password: api.Token,
 	}
 	payload := PayloadValue{ID: response.PayloadID}
+	branchRef := fmt.Sprintf("refs/heads/%s",c.Branch)
 	r, err := git.PlainClone(tempDir, false, &git.CloneOptions{
 		URL:      fmt.Sprintf("https://aperture.section.io/account/%d/application/%d/%s.git", c.AccountID, c.AppID, app.ApplicationName),
 		Auth:     gitAuth,
 		Progress: os.Stdout,
+		ReferenceName: plumbing.ReferenceName(branchRef),
 	})
 	if err != nil {
 		return err

--- a/commands/gitService.go
+++ b/commands/gitService.go
@@ -44,7 +44,7 @@ func (g *GS) UpdateGitViaGit(c *DeployCmd, response UploadResponse) error {
 		Password: api.Token,
 	}
 	payload := PayloadValue{ID: response.PayloadID}
-	branchRef := fmt.Sprintf("refs/heads/%s",c.Branch)
+	branchRef := fmt.Sprintf("refs/heads/%s",c.Environment)
 	r, err := git.PlainClone(tempDir, false, &git.CloneOptions{
 		URL:      fmt.Sprintf("https://aperture.section.io/account/%d/application/%d/%s.git", c.AccountID, c.AppID, app.ApplicationName),
 		Auth:     gitAuth,


### PR DESCRIPTION
this allows users to deploy to staging and other branches on their application.

ie:
```
section deploy -a 1887 -i 7088 -e staging
```

the standard still works (it defaults to Production)
```
section deploy -a 1887 -i 7088
```