### PR TITLE
Add builds for M1 Macs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,12 @@ jobs:
     strategy:
       matrix:
         GOOS: [ linux, darwin, windows ]
+        GOARCH: [ amd64, arm64 ]
+        exclude:
+          - GOOS: linux
+            GOARCH: arm64
+          - GOOS: windows
+            GOARCH: arm64
     env:
       VERSION: ${{ github.ref }}
       GOARCH: amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             GOARCH: arm64
     env:
       VERSION: ${{ github.ref }}
-      GOARCH: amd64
+      GOARCH: ${{ matrix.GOARCH }}
       GOOS: ${{ matrix.GOOS }}
     steps:
     - name: Set up Go 1.x

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ goerrcheck:
 build: clean
 	go build sectionctl.go
 
-export GOARCH := amd64
 build-release: clean check_version
 	@if [ -z "$(GOOS)" ]; then echo "Missing GOOS"; exit 1 ; fi
 	@if [ -z "$(GOARCH)" ]; then echo "Missing GOARCH"; exit 1 ; fi


### PR DESCRIPTION
Tested locally and works just fine: 

```
$ file sectionctl
sectionctl: Mach-O 64-bit executable arm64
$ ./sectionctl version
1.11.0 (darwin-arm64)
$ ./sectionctl whoami
Looking up current user... done
|   ATTRIBUTE   |         VALUE          |
|---------------|------------------------|
| Name          | Lindsay Holmwood       |
| Email         | lindsay@holmwood.id.au |
<snip>
```