### PR TITLE
Remove requirement for server.conf to be present for the Node.js Module

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -178,11 +178,6 @@ func IsValidNodeApp(dir string) (errs []error) {
 		}
 	}
 
-	serverConfPath := filepath.Join(dir, "server.conf")
-	if _, err := os.Stat(serverConfPath); os.IsNotExist(err) {
-		errs = append(errs, fmt.Errorf("%s is not a file (see https://github.com/section/nodejs-example/blob/master/server.conf)", serverConfPath))
-	}
-
 	return errs
 }
 


### PR DESCRIPTION
The Node.js Module itself removed the requirement for this file in December 2020.

We should also remove the creation of server.conf during `apps init` in a future PR.